### PR TITLE
Fix broken link to devcontainers website in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo holds the website for the [Development Containers Specification](https://github.com/devcontainers/spec).
 
-You may view the site at [devcontainers.github.io](https://devcontainers.github.io/containers.dev/).
+You may view the site at [devcontainers.github.io](https://devcontainers.github.io/).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo holds the website for the [Development Containers Specification](https://github.com/devcontainers/spec).
 
-You may view the site at [devcontainers.github.io](https://devcontainers.github.io/).
+You may view the site at [containers.dev](https://containers.dev/).
 
 ## Building
 


### PR DESCRIPTION
The link in the first part of the Readme.MD pointed to https://devcontainers.github.io/containers.dev/, which results in a 404. The link was changed to direct users to the homepage.