### PR TITLE
Update based on latest spec

### DIFF
--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -3,7 +3,7 @@ layout: implementors
 title:  "How to contribute to the Development Container Specification"
 shortTitle: "Contributing"
 author: Microsoft
-index: 4
+index: 5
 ---
 
 We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
@@ -23,6 +23,25 @@ Here is a sample proposal:
 - PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
 
 Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://aka.ms/devcontainer.json). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
+
+### <a href="#tool-specific-support" name="tool-specific-support" class="anchor"> Contributing tool-specific support </a>
+
+Tool-specific properties are contained in namespaces in the `"customizations"` property. For instance, VS Code specific properties are formated as:
+
+```bash
+// Configure tool-specific properties.
+"customizations": {
+     // Configure properties specific to VS Code.
+     "vscode": {
+          // Set *default* container specific settings.json values on container create.
+          "settings": {},
+			
+          // Additional VS Code specific properties...
+     }
+},
+```
+
+You may propose adding a new namespace for a specific tool, and any properties specific to that tool.
 
 ## <a href="#review-process" name="review-process" class="anchor"> Review process </a>
 

--- a/_implementors/json_reference.md
+++ b/_implementors/json_reference.md
@@ -3,7 +3,7 @@ layout: implementors
 title:  "devcontainer.json reference"
 shortTitle: "devcontainer.json reference"
 author: Microsoft
-index: 3
+index: 4
 ---
 
 A `devcontainer.json` file in your project tells [tools and services that support the dev container spec](../../supporting) how to access (or create) a **development container** with a well-defined tool and runtime stack. It follows the JSON with Comments (jsonc) format.

--- a/_implementors/json_reference.md
+++ b/_implementors/json_reference.md
@@ -56,6 +56,7 @@ The focus of `devcontainer.json` is to describe how to enrich a container for th
 | `overrideCommand` | boolean | Tells `devcontainer.json` supporting services / tools whether they should run `/bin/sh -c "while sleep 1000; do :; done"` when starting the container instead of the container's default command (since the container can shut down if the default command fails). Set to `false` if the default command must run for the container to function properly. Defaults to `true` for when using an image Dockerfile and `false` when referencing a Docker Compose file. |
 | `features` (currently in preview) | object | An object of dev container features and related options to be added into your primary container. The specific options  that are available varies by feature, so see its documentation for additional details. For example: <br />`"features": {"github-cli": "latest"}` <br /><br /> ⚠️ Currently in preview. |
 | `shutdownAction` | enum | Indicates whether `devcontainer.json` supporting tools should stop the containers when the related tool window is closed / shut down.<br>Values are  `none`, `stopContainer` (default for image or Dockerfile), and `stopCompose` (default for Docker Compose). |
+| `customizations` | object | Product specific properties, defined in [supporting tools](supporting-tools.md) |
 {: .table .table-bordered .table-responsive}
 
 ## <a href="#tool-specific" name="tool-specific" class="anchor"> Tool-specific properties </a>

--- a/_implementors/json_schema.md
+++ b/_implementors/json_schema.md
@@ -3,7 +3,7 @@ layout: implementors
 title:  "devcontainer.json schema"
 shortTitle: "devcontainer.json schema"
 author: Microsoft
-index: 2
+index: 3
 ---
 
 You may review the [current devcontainer.json schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), and the accompanying [dev-container-spec repo issue](https://github.com/microsoft/dev-container-spec/issues/14).

--- a/_implementors/reference.md
+++ b/_implementors/reference.md
@@ -3,11 +3,11 @@ layout: implementors
 title:  "Reference Implementation"
 shortTitle: "Reference Implementation"
 author: Microsoft
-index: 1
+index: 2
 ---
 
 # Reference Implementation
-The reference implementation for the specification is available through a development container CLI. This CLI can take a devcontainer.json and create and configure a dev container from it.
+The reference implementation for the specification is available through a [development container CLI](https://github.com/devcontainers/cli). This CLI can take a devcontainer.json and create and configure a dev container from it.
 
 ## What is the dev container CLI?
 When tools like VS Code and Codespaces detect a devcontainer.json file in a user's project, they use a CLI to configure a dev container. We've now opened up this CLI as a reference implementation so that individual users and other tools can read in devcontainer.json metadata and create dev containers from it.

--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -1,0 +1,160 @@
+---
+layout: implementors
+title:  "Development Container Specification"
+shortTitle: "Specification"
+author: Microsoft
+index: 1
+---
+
+# Dev container specification
+
+The purpose of the **development container** specification is to provide a way to enrich containers with the content and metadata necessary to enable development inside them. These container **environments** should be easy to use, create, and recreate. 
+
+A **development container** is a container in which a user can develop an application.  Tools that want to implement this specification should provide a set of features/commands that give more flexibility to users and allow **development containers** to scale to large development groups.
+
+An **environment** is defined as a logical instance of one or more **development containers**, along with any needed side-car containers. An environment is based on one set of metadata that can be managed as a single unit. Users can create multiple **environments** from the same configuration metadata for different purposes.
+
+Historically, dev containers have been used to enable a development workflow used either locally or in the cloud, and they've been focused on using **Docker** or **Docker Compose**. The intent of this specification and related tools is to expand the reach of **development containers**, allow the usage of containers by themselves or different orchestration technologies, and allow any tool to manage and create them.
+
+The focus of the dev container specification is to describe how to enrich a container for the purposes of development, rather than acting as a multi-container orchestrator format.  Container orchestrator formats can be referenced, when needed, to manage multiple containers and the **development container** lifecycle. Today, `devcontainer.json` includes scenario-specific properties for working without a container orchestrator (by directly referencing an image or Dockerfile) and for using Docker Compose as a simple multi-container orchestrator.
+
+# Metadata
+
+**Development containers** allow one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development.
+
+A **development container** is composed of a definition (e.g. contained in a `devcontainer.json` file) that deterministically creates containers under the control of the user.
+
+## `devcontainer.json`
+
+The current metadata schema for **development containers** is contained in a `devcontainer.json` file.
+
+The `devcontainer.json` specification contains different configuration options related to the underlying orchestrator format. At the same time, this specification leaves space for further development and implementation of other orchestrator mechanisms and file formats.
+
+While this metadata may be provided in different ways, when searching for a devcontainer.json file, products should expect to find a devcontainer.json file in one or more of the following locations (in order of precedence):
+
+.devcontainer/devcontainer.json
+.devcontainer.json
+.devcontainer/**/devcontainer.json (where ** is a sub-folder)
+
+It is valid that these files may exist in more than one location, so consider providing a mechanism for users to select one when appropriate.
+
+
+# Configuration options
+
+**Development containers** currently support multiple ways to specify the containers that create an environment. The following section describes the differences between them.
+
+## Image based
+
+Image based configurations only reference an image that should be reachable and downloadable through `docker pull` commands. Logins and tokens required for these operations are execution environment specific. The only required parameter is `image`. The details are [here](devcontainerjson-reference.md#image-or-dockerfile-specific-properties).
+
+## Dockerfile based
+
+These configurations are defined as using a `Dockerfile` to define the starting point of the **development containers**. As with image based configurations, it is assumed that any base images are already reachable by **Docker** when performing a `docker build` command. The only required parameter in this case is the relative reference to the `Dockerfile` in `build.dockerfile`. The details are [here](devcontainerjson-reference.md#image-or-dockerfile-specific-properties).
+
+There are multiple properties that allow users to control how `docker build` works:
+
+- `build.context` 
+- `build.args`
+- `build.target`,
+- `build.cacheFrom`
+
+## Docker Compose based
+
+Docker Compose configurations use `docker-compose` to create and manage a set of containers required for an application. As with the other configurations, any images required for this operation are assumed to be reachable. The required parameters are:
+
+- `build.dockerComposeFile`: the reference to the Docker Compose file(s) to be used.
+- `service`: declares the **main** container that will be used for all other operations. Tools are assumed to also use this parameter to connect to the **development container**, although they can provide facilities to connect to the other containers as required by the user.
+
+It is important to remark that due to how `docker-compose` works a lot of the properties that apply to **image** and **dockerfile** configurations can’t be set by the application and thus must be set up manually by the user using the `docker-compose` format itself.
+
+-`runServices`: the set of services in the `docker-compose` configuration that should be started or stopped with the environment.
+
+# Other options
+
+In addition to the configuration options explained above, there are other settings that apply when creating **development containers** to facilitate their use by developers. These properties mostly apply to **image** and **Dockerfile** based configurations.
+
+We describe the main ones below.
+
+## Environment Variables
+
+Environment variables can be set in containers at creation time, to override existing ones, or just to be used when a supporting tool connects to the environment.
+
+There are two kinds of environment variables:
+* Container: These variables are part of the container when it is created and are available at all points in its lifecycle.
+* Remote: This variables are to be set by a **development container** supporting tool as part of its environment when it runs. These variables can change during the lifetime of the container.
+
+## Mounts
+
+Mounts allow containers to have access to the underlying machine, share data between containers and to persist information between **development containers**. 
+
+It is important to note that these mounts are from the underlying compute environment and thus cloud environments might not have access to the same data as a local machine.
+
+## Users
+
+Users control the permissions of applications executed in the containers, allowing the developer to control them. The specification takes into account two types of user definitions:
+
+* Container User: The user that will be used for all operations that run inside a container. It is used to run lifecycle commands among others.
+* Remote User: In case the developer wants to use different users for different purposes, the remote user is the user that connecting tools should use to execute operations inside the container.
+
+
+# Lifecycle
+
+A development environment goes through different lifecycle events during its use in the outer and inner loop of development.
+
+- Configuration Validation.
+- Environment Creation.
+- Environment Stop.
+- Environment Resume.
+- Environment Connection.
+
+## Configuration Validation
+
+This section consists of actions required to validate the `devcontainer.json` configuration and does not contain values that conflict with each other.
+
+The tasks executed when validating the configuration are:
+
+- `workspace-folder` is required since it defines where the `devcontainer.json` file is located and identifies the configuration to be used for the environment.
+- Validate access to the `workspace-folder`. 
+- Validate that the metadata (for example `devcontainer.json`) contains all parameters required for the selected configuration type.
+
+## Environment Creation
+
+The creation process goes through the steps necesarry to go from the user configuration to a working **environment** that is ready to be used.
+
+### Initialization
+
+During this step, the following is executed:
+- Validate access to the container orchestrator specified by the configuration.
+- Execution of `initializeCommand`.
+
+### Image creation
+
+The first part of environment creation is generating the final image(s) that the **development containers** are going to use. This step is orchestrator dependent and can consist of just pulling a Docker image, running Docker build, or docker-compose build. Additionally, this step is useful on its own since it permits the creation of intermediate images that can be uploaded and used by other users, thus cutting down on creation time. It is encouraged that tools implementing this specification give access to a command that just executes this step.
+
+This step executes the following:
+
+- [Configuration Validation](#configuration-validation) 
+- Pull/build/execute of the defined container orchestration format to create images.
+- Validate the result of these operations.
+
+### Container Creation
+
+After image creation, containers are created based on that image and setup.
+
+This step executes the following:
+
+- Create the container with the specified properties.
+- Validate the container(s) were created successfully.
+
+### Post Container Creation
+
+- At the end of the container creation step, a set of commands are executed inside the **main** container: `on-create-command`, `update-content-command` and `post-create-command`. This set of commands is executed in sequence on a container the first time it's created and depending on the creation parameters received. You can learn more in the [documentation on lifecycle scripts](devcontainerjson-reference.md#lifecycle-scripts). By default, `post-create-command` is executed in the background after reporting the successful creation of the development environment.
+- If the `wait-for` property is defined, then execution should stop at the specified property.
+
+## Environment Stop
+
+Stops all containers in the environment. The intention of this step is to ensure all containers are stopped correctly to ensure no data is lost.
+
+## Environment Restart
+
+After an environment has been stopped, the containers are restarted according to the orchestrator defined. Additionally, `post-start-command` is executed in the **main** container.

--- a/overview.md
+++ b/overview.md
@@ -21,7 +21,7 @@ A development container defines an environment in which you develop your applica
 
 ### <a href="#build-and-test" name="build-and-test" class="anchor">  Build and test </a>
 
-Beyond repeatable setup, these same development containers provide consistency to avoid environment specific problems across developers and centralized build and test automation services. The open-source CLI reference implementation can either be used directly or integrated into product experience to use the structured metadata to deliver these benefits. It currently supports integrating with Docker Compose and a simplified, un-orchestrated single container option – so that they can be used as coding environments or for continuous integration and testing.
+Beyond repeatable setup, these same development containers provide consistency to avoid environment specific problems across developers and centralized build and test automation services. The open-source [CLI reference implementation](https://github.com/devcontainers/cli) can either be used directly or integrated into product experience to use the structured metadata to deliver these benefits. It currently supports integrating with Docker Compose and a simplified, un-orchestrated single container option – so that they can be used as coding environments or for continuous integration and testing.
 
 ### <a href="#supporting" name="supporting" class="anchor">  Supporting tools </a>
 

--- a/supporting.md
+++ b/supporting.md
@@ -4,26 +4,81 @@ layout: singlePage
 sectionid: supporting
 ---
 
-This page outlines tools and services that currently support the development container specification, including the `devcontainer.json` format.
+This page outlines tools and services that currently support the development container specification, including the `devcontainer.json` format. A `devcontainer.json` file in your project tells tools and services that support the dev container spec how to access (or create) a dev container with a well-defined tool and runtime stack.
 
 While most [dev container properties](implementors/json_reference) apply to any `devcontainer.json` supporting tool or service, a few are specific to certain tools, which are outlined below.
 
-## <a href="#devcontainer-cli" name="devcontainer-cli" class="anchor"> devcontainer CLI </a>
+## <a href="#editors" name="editors" class="anchor"> Editors </a>
 
-There will be a dev container command line interface (CLI) that can take a `devcontainer.json` and create and configure a dev container from it. The CLI allows for prebuilding dev container definitions using a CI or DevOps product like GitHub Actions. It can detect and include dev container features and apply them at container runtime, and run [lifecycle commands](implementors/json_reference/#lifecycle-scripts) like `postCreateCommand`, providing more power than a plain `docker build` and `docker run`.
+### <a href="#visual-studio-code" name="visual-studio-code" class="anchor"> Visual Studio Code </a>
 
-The publishing of this CLI is being discussed in a [dev-container-spec issue](https://github.com/microsoft/dev-container-spec/issues/9) and will be available on the [reference page](implementors/reference) of this site.
+Visual Studio Code specific properties go under `vscode` inside `customizations`.
 
-## <a href="#github-codespaces" name="github-codespaces" class="anchor"> GitHub Codespaces </a>
+```json
+"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			"extensions": [],
+		}
+}
+```
+
+| Property | Type  | Description |
+|:------------------|:------------|:------------|
+| `extensions` | array | An array of extension IDs that specify the extensions that should be installed inside the container when it is created. Defaults to `[]`. |
+| `settings` | object | Adds default `settings.json` values into a container/machine specific settings file. Defaults to `{}`. |
+{: .table .table-bordered .table-responsive}
+
+Please note that [Remote - Containers](#remote-containers) and [GitHub Codespaces](#github-codespaces) support the VS Code properties.
+
+## <a href="#tools" name="tools" class="anchor"> Tools </a>
+
+## <a href="#devcontainer-cli" name="devcontainer-cli" class="anchor"> Dev container CLI </a>
+
+A dev container command line interface (CLI) that implements this specification. It is in development in the [devcontainers/cli](https://github.com/devcontainers/cli) repo.
+
+The CLI can take a `devcontainer.json` and create and configure a dev container from it. It allows for prebuilding dev container definitions using a CI or DevOps product like GitHub Actions. It can detect and include dev container features and apply them at container runtime, and run [lifecycle commands](implementors/json_reference/#lifecycle-scripts) like `postCreateCommand`, providing more power than a plain `docker build` and `docker run`.
+
+### <a href="#remote-containers-cli" name="remote-containers-cli" class="anchor"> Remote - Containers CLI </a>
+
+There is a Remote - Containers [`devcontainer` CLI](https://code.visualstudio.com/docs/remote/devcontainer-cli) which may be installed within Remote - Containers or through the command line.
+
+### <a href="#remote-containers" name="remote-containers" class="anchor"> Visual Studio Code Remote - Containers </a>
+
+The [**Visual Studio Code Remote - Containers** extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) lets you use a [Docker container](https://docker.com) as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set. There is more information in the Remote - Containers [documentation](https://code.visualstudio.com/docs/remote/containers).
+
+> **Tip:** If you make a change to your dev container after having built and connected to it, be sure to run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
+
+#### <a href="#product-specific-properties" name="product-specific-properties" class="anchor"> Product specific properties </a>
+
+Remote containers implements the [VS Code properties](#visual-studio-code) specific properties.
+
+#### <a href="#remote-containers-code-specific-limitations" name="remote-containers-specific-limitations" class="anchor"> Product specific limitations </a>
+
+Some properties may also have certain limitations in the Remote - Containers extension.
+
+| Property or variable | Type  | Description |
+|:------------------|:------------|:------------|
+| `workspaceMount` | string | Not yet supported when using Clone Repository in Container Volume. |
+| `workspaceFolder` | string | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolder}`  | Any | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolderBasename}` | Any | Not yet supported when using Clone Repository in Container Volume. |
+{: .table .table-bordered .table-responsive}
+
+### <a href="#github-codespaces" name="github-codespaces" class="anchor"> GitHub Codespaces </a>
 
 A [codespace](https://docs.github.com/en/codespaces/overview) is a development environment that's hosted in the cloud. Codespaces run on a variety of VM-based compute options hosted by GitHub.com, which you can configure from 2 core machines up to 32 core machines. You can connect to your codespaces from the browser or locally using Visual Studio Code.
 
 > **Tip:** If you make a change to your dev container after having built and connected to your codespace, be sure to run **Codespaces: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
 
-### <a href="#codespaces-specific-properties" name="codespaces-specific-properties" class="anchor"> Product specific properties </a>
-GitHub Codespaces works with a growing number of tools and, where applicable, their `devcontainer.json` properties. For example, connecting the Codespaces web editor or VS Code enables the use of [VS Code properties](#visual-studio-code-specific-properties).
+#### <a href="#codespaces-specific-properties" name="codespaces-specific-properties" class="anchor"> Product specific properties </a>
+GitHub Codespaces works with a growing number of tools and, where applicable, their `devcontainer.json` properties. For example, connecting the Codespaces web editor or VS Code enables the use of [VS Code properties](#visual-studio-code).
 
-### <a href="#codespaces-specific-limitations" name="codespaces-specific-limitations" class="anchor"> Product specific limitations </a>
+#### <a href="#codespaces-specific-limitations" name="codespaces-specific-limitations" class="anchor"> Product specific limitations </a>
+
+Some properties may apply differently to Codespaces.
 
 | Property or variable | Type  | Description |
 |:------------------|:------------|:------------|
@@ -36,38 +91,6 @@ GitHub Codespaces works with a growing number of tools and, where applicable, th
 | `${localEnv:VARIABLE_NAME}` | Any | For Codespaces, the host is in the cloud rather than your local machine.|
 {: .table .table-bordered .table-responsive}
 
-## <a href="#visual-studio-code-remote-containers" name="visual-studio-code-remote-containers" class="anchor"> Visual Studio Code Remote - Containers </a>
-
-The [**Visual Studio Code Remote - Containers** extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) lets you use a [Docker container](https://docker.com) as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set. There is more information in the Remote - Containers [documentation](https://code.visualstudio.com/docs/remote/containers).
-
-> **Tip:** If you make a change to your dev container after having built and connected to it, be sure to run **Remote-Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
-
-### <a href="#visual-studio-code-specific-properties" name="visual-studio-code-specific-properties" class="anchor"> Product specific properties </a>
-
-Some properties are specific to VS Code. Please note that Codespaces supports these VS Code properties.
-
-| Property | Type  | Description |
-|:------------------|:------------|:------------|
-| `extensions` | array | An array of extension IDs that specify the extensions that should be installed inside the container when it is created. Defaults to `[]`. |
-| `settings` | object | Adds default `settings.json` values into a container/machine specific settings file. Defaults to `{}`. |
-{: .table .table-bordered .table-responsive}
-
-### <a href="#visual-studio-code-specific-limitations" name="visual-studio-code-specific-limitations" class="anchor"> Product specific limitations </a>
-
-Some properties may also have certain limitations in the Remote - Containers extension.
-
-| Property or variable | Type  | Description |
-|:------------------|:------------|:------------|
-| `workspaceMount` | string | Not yet supported when using Clone Repository in Container Volume. |
-| `workspaceFolder` | string | Not yet supported when using Clone Repository in Container Volume. |
-| `${localWorkspaceFolder}`  | Any | Not yet supported when using Clone Repository in Container Volume. |
-| `${localWorkspaceFolderBasename}` | Any | Not yet supported when using Clone Repository in Container Volume. |
-{: .table .table-bordered .table-responsive}
-
-## <a href="#remote-containers-cli" name="remote-containers-cli" class="anchor"> Remote - Containers CLI </a>
-
-There is a Remote - Containers [`devcontainer` CLI](https://code.visualstudio.com/docs/remote/devcontainer-cli) which may be installed within Remote - Containers or through the command line.
-
-## <a href="#schema" name="schema" class="anchor"> Schema </a>
+### <a href="#schema" name="schema" class="anchor"> Schema </a>
 
 You can explore the [VS Code implementation](implementors/json_schema) of the dev container schema.

--- a/supporting.md
+++ b/supporting.md
@@ -76,6 +76,23 @@ A [codespace](https://docs.github.com/en/codespaces/overview) is a development e
 #### <a href="#codespaces-specific-properties" name="codespaces-specific-properties" class="anchor"> Product specific properties </a>
 GitHub Codespaces works with a growing number of tools and, where applicable, their `devcontainer.json` properties. For example, connecting the Codespaces web editor or VS Code enables the use of [VS Code properties](#visual-studio-code).
 
+If your Codespaces project needs additional permissions for other repositories, you can configure this through the `repositories` and `permissions` properties. You may learn more about this in the [Codespaces documentation](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-repository-access-for-your-codespaces). As with other tools, Codespaces specific properties are placed within a `codespaces` namespace inside the `customizations` property.
+
+```json
+"customizations": {
+		// Configure properties specific to Codespaces.
+		"codespaces": {
+			"repositories": {
+				"my_org/my_repo": {
+					"permissions": {
+						"issues": "write"
+					}
+				}
+			}
+		}
+}
+```
+
 #### <a href="#codespaces-specific-limitations" name="codespaces-specific-limitations" class="anchor"> Product specific limitations </a>
 
 Some properties may apply differently to Codespaces.


### PR DESCRIPTION
Update the containers.dev web content with the latest updates:
- Spec content
- Links to CLI repo
- Update support tools based on [latest spec](https://github.com/devcontainers/spec/blob/main/docs/specs/supporting-tools.md)
- Add `customizations` to contributing.md and the devcontainer.json reference