### PR TITLE
Add padding to various elements

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -471,3 +471,12 @@ a:hover {
 		font-size: 14px;
 	}
 }
+
+.dap-sidebar .card {
+	padding-top: 1px;
+}
+
+h1 a, h2 a, h3 a, h4 a, a h3 {
+	padding-top: 2px;
+	padding-bottom: 2px;
+}


### PR DESCRIPTION
This PR fixes the padding of various elements on the site so that the outline borders aren't clipped off or shaped irregularly.

In the example below, the middle link has the new CSS, and the other two links don't.

![A screencap showing the middle button of the site with the fix, and the other two buttons without the fix. The button with the fix has a rectangular border, whereas the other two buttons have irregular borders.](https://user-images.githubusercontent.com/7199958/172442983-760d4f3f-7a94-4e1a-b609-3a977fcabd27.gif)
