### PR TITLE
Display all crawled dev container features 

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,50 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Publish to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["gh-pages"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -27,13 +23,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install Oras
+        run: |
+          curl -LO https://github.com/oras-project/oras/releases/download/v0.13.0/oras_0.13.0_linux_amd64.tar.gz
+          mkdir -p oras-install/
+          tar -zxf oras_0.13.0_*.tar.gz -C oras-install/
+          mv oras-install/oras /usr/local/bin/
+          rm -rf oras_0.13.0_*.tar.gz oras-install/
+
+      - name: Fetch devcontainer-index.json
+        run: |
+          cd _data
+          oras pull ghcr.io/devcontainers/index:latest
+
       - name: Setup Pages
         uses: actions/configure-pages@v1
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
           destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           cd _data
           oras pull ghcr.io/devcontainers/index:latest
+          cp devcontainer-index.json ../static/
 
       - name: Setup Pages
         uses: actions/configure-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ npm-debug.log
 _site
 spec-generator/node_modules
 spec-generator/out
-_data/devcontainer-index.json
+devcontainer-index.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 _site
 spec-generator/node_modules
 spec-generator/out
+_data/devcontainer-index.json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,4 +228,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.11
+   2.3.20

--- a/collections.html
+++ b/collections.html
@@ -23,7 +23,7 @@ sectionid: collection-index
 {% for c in site.data.collection-index %}
 <tr>
     <td class="tg-0lax">{{ c.name }}</td>
-    <td class="tg-0lax"><a href="{{ c.contact | strip_html  }}">{{ c.maintainer | strip_html  }}</a></td>
-    <td class="tg-0lax"><a href="{{ c.repository | strip_html  }}">{{ c.repository | strip_html  }}</a></td>
+    <td class="tg-0lax"><a rel="nofollow" href="{{ c.contact | strip_html  }}">{{ c.maintainer | strip_html  }}</a></td>
+    <td class="tg-0lax"><a rel="nofollow" href="{{ c.repository | strip_html  }}">{{ c.repository | strip_html  }}</a></td>
 </tr>
 {% endfor %}

--- a/collections.html
+++ b/collections.html
@@ -23,7 +23,7 @@ sectionid: collection-index
 {% for c in site.data.collection-index %}
 <tr>
     <td class="tg-0lax">{{ c.name }}</td>
-    <td class="tg-0lax"><a href="{{ c.contact }}">{{ c.maintainer }}</a></td>
-    <td class="tg-0lax"><a href="{{ c.repository }}">{{ c.repository }}</a></td>
+    <td class="tg-0lax"><a href="{{ c.contact | strip_html  }}">{{ c.maintainer | strip_html  }}</a></td>
+    <td class="tg-0lax"><a href="{{ c.repository | strip_html  }}">{{ c.repository | strip_html  }}</a></td>
 </tr>
 {% endfor %}

--- a/features.html
+++ b/features.html
@@ -6,8 +6,11 @@ sectionid: collection-index-features
 
 <h1 style="margin-left: auto;margin-right: auto;">Available Features</h1>
 <p style="margin-left: auto;margin-right: auto;">
-    This list contains 
-
+    This table contains all official and community-supported <a href="implementors/features/">dev container features</a>
+    known at the time of crawling <a href="/collections">each registered collection</a>. This list is continuously 
+    updated with the latest available feature information.
+    <br><br>
+    Referencing a feature below can be done in the 'features' section of a devcontainer.json.
 
 </p>
 
@@ -15,14 +18,20 @@ sectionid: collection-index-features
 </p>
 <tr>
     <td class="tg-0lax"><b>Feature Name</b></b></td>
-    <td class="tg-0lax"><b>Author</b></td>
-    <td class="tg-0lax"><b>Latest Reference</b></td>
+    <td class="tg-0lax"><b>Maintainer</b></td>
+    <td class="tg-0lax"><b>Reference</b></td>
+    <td class="tg-0lax"><b>Latest Version</b></td>
+
 </tr>
 
-{% for c in site.data.devcontainer-index.features %}
-<tr>
-    <td class="tg-0lax"><a href="{{ c.documentationURL }}">{{ c.name }}</a></td>
-    <td class="tg-0lax">{{ c.author }}</td>
-    <td class="tg-0lax"><code>{{ c.id }}:{{ c.version }}</code></td>
-</tr>
+{% for c in site.data.devcontainer-index.collections %}
+    {% for f in c.features %}
+    <tr>
+        <td class="tg-0lax"><a href="{{ f.documentationURL }}">{{ f.name }}</a></td>
+        <td class="tg-0lax">{{ c.sourceInformation.maintainer }}</td>
+        <td class="tg-0lax"><code>{{ f.id }}</code></td>
+        <td class="tg-0lax"><code>{{ f.version }}</code></td>
+    </tr>
+    {% endfor %}
+
 {% endfor %}

--- a/features.html
+++ b/features.html
@@ -25,7 +25,7 @@ sectionid: collection-index-features
 {% for c in site.data.devcontainer-index.collections %}
     {% for f in c.features %}
     <tr>
-        <td class="tg-0lax"><a href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
+        <td class="tg-0lax"><a rel="nofollow" href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
         <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html  }}</td>
         <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
         <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>

--- a/features.html
+++ b/features.html
@@ -1,0 +1,26 @@
+---
+title: Features
+layout: table
+sectionid: collection-index
+---
+
+<h1 style="margin-left: auto;margin-right: auto;">Features</h1>
+<p style="margin-left: auto;margin-right: auto;">
+    Crawled Features
+</p>
+
+<p>
+</p>
+<tr>
+    <td class="tg-0lax"><b>Feature Name</b></b></td>
+    <td class="tg-0lax"><b>Reference</b></td>
+    <td class="tg-0lax"><b>Latest Version</b></td>
+</tr>
+
+{% for c in site.data.devcontainer-index.features %}
+<tr>
+    <td class="tg-0lax">{{ c.name }}</td>
+    <td class="tg-0lax"><code>{{ c.id }}</code></td>
+    <td class="tg-0lax"><a href="{{ c.repository }}">{{ c.version }}</a></td>
+</tr>
+{% endfor %}

--- a/features.html
+++ b/features.html
@@ -7,7 +7,7 @@ sectionid: collection-index-features
 <h1 style="margin-left: auto;margin-right: auto;">Available Features</h1>
 <p style="margin-left: auto;margin-right: auto;">
     This table contains all official and community-supported <a href="implementors/features/">dev container features</a>
-    known at the time of crawling <a href="/collections">each registered collection</a>. This list is continuously 
+    known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously 
     updated with the latest available feature information.
     <br><br>
     Referencing a feature below can be done in the 'features' section of a devcontainer.json.

--- a/features.html
+++ b/features.html
@@ -1,26 +1,28 @@
 ---
 title: Features
 layout: table
-sectionid: collection-index
+sectionid: collection-index-features
 ---
 
-<h1 style="margin-left: auto;margin-right: auto;">Features</h1>
+<h1 style="margin-left: auto;margin-right: auto;">Available Features</h1>
 <p style="margin-left: auto;margin-right: auto;">
-    Crawled Features
+    This list contains 
+
+
 </p>
 
 <p>
 </p>
 <tr>
     <td class="tg-0lax"><b>Feature Name</b></b></td>
-    <td class="tg-0lax"><b>Reference</b></td>
-    <td class="tg-0lax"><b>Latest Version</b></td>
+    <td class="tg-0lax"><b>Author</b></td>
+    <td class="tg-0lax"><b>Latest Reference</b></td>
 </tr>
 
 {% for c in site.data.devcontainer-index.features %}
 <tr>
-    <td class="tg-0lax">{{ c.name }}</td>
-    <td class="tg-0lax"><code>{{ c.id }}</code></td>
-    <td class="tg-0lax"><a href="{{ c.repository }}">{{ c.version }}</a></td>
+    <td class="tg-0lax"><a href="{{ c.documentationURL }}">{{ c.name }}</a></td>
+    <td class="tg-0lax">{{ c.author }}</td>
+    <td class="tg-0lax"><code>{{ c.id }}:{{ c.version }}</code></td>
 </tr>
 {% endfor %}

--- a/features.html
+++ b/features.html
@@ -21,7 +21,6 @@ sectionid: collection-index-features
     <td class="tg-0lax"><b>Maintainer</b></td>
     <td class="tg-0lax"><b>Reference</b></td>
     <td class="tg-0lax"><b>Latest Version</b></td>
-
 </tr>
 
 {% for c in site.data.devcontainer-index.collections %}

--- a/features.html
+++ b/features.html
@@ -10,8 +10,7 @@ sectionid: collection-index-features
     known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously 
     updated with the latest available feature information.
     <br><br>
-    Referencing a feature below can be done in the 'features' section of a devcontainer.json.
-
+    <a href="implementors/features#referencing-a-feature">Referencing a feature</a> below can be done in the 'features' section of a devcontainer.json.
 </p>
 
 <p>
@@ -26,10 +25,10 @@ sectionid: collection-index-features
 {% for c in site.data.devcontainer-index.collections %}
     {% for f in c.features %}
     <tr>
-        <td class="tg-0lax"><a href="{{ f.documentationURL }}">{{ f.name }}</a></td>
-        <td class="tg-0lax">{{ c.sourceInformation.maintainer }}</td>
-        <td class="tg-0lax"><code>{{ f.id }}</code></td>
-        <td class="tg-0lax"><code>{{ f.version }}</code></td>
+        <td class="tg-0lax"><a href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
+        <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html  }}</td>
+        <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
+        <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>
     </tr>
     {% endfor %}
 


### PR DESCRIPTION
Features are crawled based on the collection indexed added in https://github.com/devcontainers/devcontainers.github.io/pull/24

Those references are then injected into the website at build time with the new GitHub build action.  

NOTE: When this is merged, the "source" found in the [Pages settings](https://github.com/devcontainers/devcontainers.github.io/settings/pages)  on this repo will need to be changed from 'Deploy from a Branch' to 'GitHub Actions'