### PR TITLE
Adds rocker-org/devcontainer-features to the feature collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -8,3 +8,8 @@
   contact: https://github.com/iterative/features/issues
   repository: https://github.com/iterative/features
   ociReference: ghcr.io/iterative/features
+- name: Features for R
+  maintainer: Rocker Project
+  contact: https://github.com/rocker-org/devcontainer-features/issues
+  repository: https://github.com/rocker-org/devcontainer-features
+  ociReference: ghcr.io/rocker-org/devcontainer-features


### PR DESCRIPTION
Adds https://github.com/rocker-org/devcontainer-features to the collection.

For now, it includes a feature that installs any version of R and a feature that installs [quarto-cli](https://github.com/quarto-dev/quarto-cli), a popular choice for R users.
(quarto-cli has no dependency on R)

We may add features such as the ability to set up R in a different way in the future.

cc @cboettig @eddelbuettel