### PR TITLE
Update links to spec repo

### DIFF
--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -10,7 +10,7 @@ We're excited for your contributions to the Dev Container Specification! This do
 
 ## <a href="#contribution-approaches" name="contribution-approaches" class="anchor"> Contribution approaches </a>
 
-- Propose the change via an [issue](https://github.com/microsoft/dev-container-spec/issues) in the [dev-container-spec repo](https://github.com/microsoft/dev-container-spec). Try to get early feedback before spending too much effort formalizing it.
+- Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in the [spec repo](https://github.com/devcontainers/spec). Try to get early feedback before spending too much effort formalizing it.
 - More formally document the proposed change in terms of properties and their semantics. Look to format your proposal like our [devcontainer.json reference](../json_reference), which is a JSON with Comments (jsonc) format.
 
 Here is a sample proposal:
@@ -45,9 +45,9 @@ You may propose adding a new namespace for a specific tool, and any properties s
 
 ## <a href="#review-process" name="review-process" class="anchor"> Review process </a>
 
-We use the following [labels](https://github.com/microsoft/dev-container-spec/labels) in the dev-container-spec repo:
+We use the following [labels](https://github.com/devcontainers/spec/labels) in the spec repo:
 
 - `proposal`: Issues under discussion, still collecting feedback.
 - `finalization`: Proposals we intend to make part of the spec.
 
-[Milestones](https://github.com/microsoft/dev-container-spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.
+[Milestones](https://github.com/devcontainers/spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,10 +15,10 @@
                         <span class="message">Hello from Seattle and Zürich.</span>
                     </li>
                     <li>
-                        <a class="github-button" href="https://github.com/Microsoft/dev-container-spec" data-icon="octicon-star" data-show-count="true" aria-label="Star Microsoft/dev-container-spec on GitHub">Star</a>
+                        <a class="github-button" href="https://github.com/devcontainers/spec" data-icon="octicon-star" data-show-count="true" aria-label="Star devcontainers/spec on GitHub">Star</a>
                     </li>
                     <li>
-                        <a class="github-button" href="https://github.com/Microsoft/dev-container-spec/subscription" aria-label="Watch Microsoft/dev-container-spec on GitHub">Watch</a>
+                        <a class="github-button" href="https://github.com/devcontainers/spec/subscription" aria-label="Watch devcontainers/spec on GitHub">Watch</a>
                     </li>
                 </ul>
             </div>

--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,7 @@ We're excited for your contributions to the dev container specification! This do
 ## Contribution approaches
 
 If you'd like to contribute a change or addition to the spec, you may follow the guidance below:
-- Propose the change via an [issue](https://github.com/microsoft/dev-container-spec/issues) in this repository. Try to get early feedback before spending too much effort formalizing it.
+- Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in this repository. Try to get early feedback before spending too much effort formalizing it.
 - More formally document the proposed change in terms of properties and their semantics. Look to format your proposal like our [devcontainer.json reference](https://aka.ms/devcontainer.json).
 
 Here is a sample:
@@ -42,9 +42,9 @@ If you'd like to discuss the spec, such as asking questions, providing feedback,
 
 ## Review process
 
-We use the following [labels](https://github.com/microsoft/dev-container-spec/labels):
+We use the following [labels](https://github.com/devcontainers/spec/labels):
 
 - `proposal`: Issues under discussion, still collecting feedback.
 - `finalization`: Proposals we intend to make part of the spec.
 
-[Milestones](https://github.com/microsoft/dev-container-spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.
+[Milestones](https://github.com/devcontainers/spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ layout: default
         <br />
         <div class="intro-text">
             <a class="github-button" href="https://github.com/devcontainers/spec" data-size="large" data-icon="octicon-star" data-show-count="true" tabindex="0"
-                aria-label="Star Microsoft/dev-container-spec on GitHub">Star</a>
+                aria-label="Star devcontainers/spec on GitHub">Star</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/devcontainers/devcontainers.github.io/issues/39 along with other outdated links.