### PR TITLE
Add public Meaningful features in collection index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -18,3 +18,8 @@
   contact: https://github.com/rocker-org/devcontainer-features/issues
   repository: https://github.com/rocker-org/devcontainer-features
   ociReference: ghcr.io/rocker-org/devcontainer-features
+- name: Public Meaningful Features
+  maintainer: Meaningful
+  contact: https://github.com/meaningful-ooo/devcontainer-features/issues
+  repository: https://github.com/meaningful-ooo/devcontainer-features
+  ociReference: ghcr.io/meaningful-ooo/devcontainer-features


### PR DESCRIPTION
Add a repository of features maintained by [Meaningful](https://meaningful.ooo). It includes some community-maintained features from https://github.com/Microsoft/vscode-dev-containers ported to the new devcontainer feature spec.

Reference: https://github.com/microsoft/vscode-dev-containers/issues/1589#issuecomment-1275106375