### PR TITLE
Add mpriscella/features to collection index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -8,7 +8,7 @@
   contact: https://github.com/devcontainers/templates/issues
   repository: https://github.com/devcontainers/templates
   ociReference: ghcr.io/devcontainers/templates
-- name: Iterative Tools for Machine Learning Features 
+- name: Iterative Tools for Machine Learning Features
   maintainer: Iterative, Inc
   contact: https://github.com/iterative/features/issues
   repository: https://github.com/iterative/features
@@ -23,6 +23,11 @@
   contact: https://github.com/meaningful-ooo/devcontainer-features/issues
   repository: https://github.com/meaningful-ooo/devcontainer-features
   ociReference: ghcr.io/meaningful-ooo/devcontainer-features
+- name: Assorted Features
+  maintainer: Mike Priscella
+  contact: https://github.com/mpriscella/features/issues
+  repository: https://github.com/mpriscella/features
+  ociReference: ghcr.io/mpriscella/features
 - name: Legacy Community Templates
   maintainer: Deprecated (No longer maintained)
   contact: https://github.com/microsoft/vscode-dev-containers/issues/1589

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -23,13 +23,13 @@
   contact: https://github.com/meaningful-ooo/devcontainer-features/issues
   repository: https://github.com/meaningful-ooo/devcontainer-features
   ociReference: ghcr.io/meaningful-ooo/devcontainer-features
-- name: Assorted Features
-  maintainer: Mike Priscella
-  contact: https://github.com/mpriscella/features/issues
-  repository: https://github.com/mpriscella/features
-  ociReference: ghcr.io/mpriscella/features
 - name: Legacy Community Templates
   maintainer: Deprecated (No longer maintained)
   contact: https://github.com/microsoft/vscode-dev-containers/issues/1589
   repository: https://github.com/microsoft/vscode-dev-containers
   ociReference: ghcr.io/microsoft/vscode-dev-containers
+- name: Assorted Features
+  maintainer: Mike Priscella
+  contact: https://github.com/mpriscella/features/issues
+  repository: https://github.com/mpriscella/features
+  ociReference: ghcr.io/mpriscella/features


### PR DESCRIPTION
Adds https://github.com/mpriscella/features to the collection index.

I couldn't find any guidance on submitting a personal collection of features, but figured it was worth the PR. These are features to add a series of command line tools that I've found useful professionally and personally.

If a personal collection is inappropriate for this, please let me know and I'll find an alternate solution.