### PR TITLE
Adds rocker-org/devcontainer-templates to the collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -18,6 +18,11 @@
   contact: https://github.com/rocker-org/devcontainer-features/issues
   repository: https://github.com/rocker-org/devcontainer-features
   ociReference: ghcr.io/rocker-org/devcontainer-features
+- name: Templates for R
+  maintainer: Rocker Project
+  contact: https://github.com/rocker-org/devcontainer-templates/issues
+  repository: https://github.com/rocker-org/devcontainer-templates
+  ociReference: ghcr.io/rocker-org/devcontainer-templates
 - name: Public Meaningful Features
   maintainer: Meaningful
   contact: https://github.com/meaningful-ooo/devcontainer-features/issues


### PR DESCRIPTION
We have created a template repo for the purpose of replacing the old R template (https://github.com/microsoft/vscode-dev-containers/tree/main/containers/r).
I believe you can remove the old R template in favor of the new template (https://github.com/rocker-org/devcontainer-templates/tree/main/src/r-ver).

Other templates may be added in the future.

cc @cboettig @eddelbuettel