### PR TITLE
Adds eitsupi/devcontainer-features to the collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -43,3 +43,8 @@
   contact: https://github.com/devcontainers-contrib/features/issues
   repository: https://github.com/devcontainers-contrib/features
   ociReference: ghcr.io/devcontainers-contrib/features
+- name: Assorted Features
+  maintainer: eitsupi
+  contact: https://github.com/eitsupi/devcontainer-features/issues
+  repository: https://github.com/eitsupi/devcontainer-features
+  ociReference: ghcr.io/eitsupi/devcontainer-features


### PR DESCRIPTION
Although jq is included in the debian common utils feature, I often also want to use yq, so I have released a simple feature that simply installs yq (and gojq).
I hope it will be useful for people like me.