### PR TITLE
One less preview, capitalization, template template

### DIFF
--- a/_implementors/features-distribution.md
+++ b/_implementors/features-distribution.md
@@ -6,7 +6,7 @@ author: Microsoft
 index: 6
 ---
 
-**TL;DR Check out the [quick start template](https://github.com/devcontainers/feature-template) to get going on distributing your own Dev Container Features.**
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get started on distributing your own Dev Container Features.**
 
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container 'Features'](../features). 
 

--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -143,7 +143,7 @@ In addition to the configuration options explained above, there are other settin
 
 A complete list of available metadata properties and their purposes can be found in the [`devcontainer.json` reference](https://aka.ms/devcontainer.json). However, we will describe the critical ones below in more detail.
 
-## <a href="#features-preview" name="features-preview" class="anchor"> Features (preview) </a>
+## <a href="#features" name="features" class="anchor"> Features</a>
 
 Development container "Features" are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "features" into your development container for you or your collaborators to use.
 

--- a/_implementors/templates-distribution.md
+++ b/_implementors/templates-distribution.md
@@ -6,7 +6,7 @@ author: Microsoft
 index: 10
 ---
 
-**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get started on distributing your own Dev Container Features.**
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get started on distributing your own Dev Container Templates.**
 
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Templates](/implementors/templates). 
 

--- a/_implementors/templates-distribution.md
+++ b/_implementors/templates-distribution.md
@@ -6,6 +6,8 @@ author: Microsoft
 index: 10
 ---
 
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get started on distributing your own Dev Container Features.**
+
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Templates](/implementors/templates). 
 
 Goals include:

--- a/collections.html
+++ b/collections.html
@@ -6,8 +6,8 @@ sectionid: collection-index
 
 <h1 style="margin-left: auto;margin-right: auto;">Collections</h1>
 <p style="margin-left: auto;margin-right: auto;">
-    This list below contains pointers to official and community-contributed dev container assets, including Features and Templates.
-    Collections on this list are continuously crawled for liveness, and can be presented in UX of dev container-supporting tools 
+    This list below contains pointers to official and community-contributed Dev Container assets, including Features and Templates.
+    Collections on this list are continuously crawled for liveness, and can be presented in UX of Dev Container-supporting tools 
     (i.e. it will be presented in the GitHub Codespaces and VS Code Dev Containers UX).
 </p>
 

--- a/features.html
+++ b/features.html
@@ -4,13 +4,14 @@ layout: table
 sectionid: collection-index-features
 ---
 
-<h1 style="margin-left: auto;margin-right: auto;">Available Features</h1>
+<h1 style="margin-left: auto;margin-right: auto;">Available Dev Container Features</h1>
 <p style="margin-left: auto;margin-right: auto;">
-    This table contains all official and community-supported <a href="implementors/features/">dev container features</a>
+    This table contains all official and community-supported <a href="implementors/features/">Dev Container Features</a>
     known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously 
-    updated with the latest available feature information.
+    updated with the latest available feature information. See the <a href="https://github.com/devcontainers/feature-template">
+    Feature quick start repository</a> to add your own!
     <br><br>
-    <a href="implementors/features#referencing-a-feature">Referencing a feature</a> below can be done in the 'features' section of a devcontainer.json.
+    <a href="implementors/features#referencing-a-feature">Referencing a feature</a> below can be done in the "features" section of a devcontainer.json.
 </p>
 
 <p>

--- a/templates.html
+++ b/templates.html
@@ -4,11 +4,12 @@ layout: table
 sectionid: collection-index-templates
 ---
 
-<h1 style="margin-left: auto;margin-right: auto;">Available Templates</h1>
+<h1 style="margin-left: auto;margin-right: auto;">Available Dev Container Templates</h1>
 <p style="margin-left: auto;margin-right: auto;">
     This table contains all official and community-supported <a href="implementors/templates/">Dev Container Templates</a>
     known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously 
-    updated with the latest available Template information.
+    updated with the latest available Template information. See the <a href="https://github.com/devcontainers/template-starter">
+    Template quick start repository</a> to add your own!
     <br><br>
     Templates listed here will be presented in the UX of <a href="supporting">supporting tools</a>.
 </p>


### PR DESCRIPTION
Noticed we had one spot that still said Features was in preview, and went ahead and fixed some capitalization, and added references to the template starter.  I also added a reference to the feature template (soon to be know as feature starter) in the Available Features page to help raise awareness.