### PR TITLE
Add pnpm feature

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -78,3 +78,8 @@
   contact: https://github.com/natescherer/devcontainers-custom-features/issues
   repository: https://github.com/natescherer/devcontainers-custom-features
   ociReference: ghcr.io/natescherer/devcontainers-custom-features
+- name: pnpm (requires npm)
+  maintainer: NicoVIII
+  contact: https://github.com/NicoVIII/devcontainer-features/issues
+  repository: https://github.com/NicoVIII/devcontainer-features
+  ociReference: ghcr.io/NicoVIII/devcontainer-features


### PR DESCRIPTION
I wrote a very simple pnpm feature (which depends on the existence of npm and defines an installsAfter for the node-Feature).

It was suggested to add it to the index:
https://github.com/devcontainers/features/issues/256#issuecomment-1305973889

Therefore I opened this PR here.
If I did something wrong, please tell me :)