### PR TITLE
add saml-to/devcontainer-features

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -108,3 +108,8 @@
   contact: https://github.com/enricosecondulfo/devcontainer-features/issues
   repository: https://github.com/enricosecondulfo/devcontainer-features
   ociReference: ghcr.io/enricosecondulfo/devcontainer-features
+- name: SAML.to Development Container Features
+  maintainer: saml-to
+  contact: https://github.com/saml-to/devcontainer-features/issues
+  repository: https://github.com/saml-to/devcontainer-features
+  ociReference: ghcr.io/saml-to/devcontainer-features


### PR DESCRIPTION
Greetings!

We've made the ability to Assume AWS Roles in Dev Containers.

Here's our PR to add https://github.com/saml-to/devcontainer-features to the index!

Cheers,
Christian