### PR TITLE
Fix broken link on spec page

### DIFF
--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -147,7 +147,7 @@ A complete list of available metadata properties and their purposes can be found
 
 Development container "Features" are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "features" into your development container for you or your collaborators to use.
 
-They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [features documentation](./features) for more details.
+They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [features documentation](../features) for more details.
 
 ## <a href="#environment-variables" name="environment-variables" class="anchor"> Environment variables </a>
 

--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -147,7 +147,7 @@ A complete list of available metadata properties and their purposes can be found
 
 Development container "Features" are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "features" into your development container for you or your collaborators to use.
 
-They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [features documentation](./features.md) for more details.
+They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [features documentation](./features) for more details.
 
 ## <a href="#environment-variables" name="environment-variables" class="anchor"> Environment variables </a>
 


### PR DESCRIPTION
Fixes a broken link on `/implementors/spec`

Current site:

![Broken link](https://user-images.githubusercontent.com/19893438/203102935-4a3a8670-f0a0-429d-858b-81cfa7f3953f.gif)

This change:

![Working link](https://user-images.githubusercontent.com/19893438/203103157-242d57f9-e1f9-471a-99ce-d0ac28f39cf6.gif)