### PR TITLE
Remove the <source> that messes it up in dark mode

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,10 +28,7 @@
                     <li>
                         <div class="copyright">
                             <a id="footer-microsoft-link" class="logo" href="https://www.microsoft.com">
-                                <picture>
-                                    <source srcset="{{site.baseurl}}/img/microsoft-logo.png" media="(prefers-color-scheme: dark)"></source>
-                                    <img src="{{site.baseurl}}/img/microsoft-logo-inverted.png" height="20" alt="Microsoft">
-                                </picture>
+                                <img src="{{site.baseurl}}/img/microsoft-logo-inverted.png" height="20" alt="Microsoft">
                             </a>
                             <span>© 2022 Microsoft</span>
                         </div>


### PR DESCRIPTION
Fixes #88

> It appears that this is only caused when the viewer is in Dark Mode when `@media (prefers-color-scheme: dark)` matches.
> 
> |Light mode | Dark mode |
> |---|---|
> |![image](https://user-images.githubusercontent.com/61068799/204680908-debbbd3a-18e6-425b-9895-e8cea9491253.png)|![image](https://user-images.githubusercontent.com/61068799/204680979-4512ce23-ccdb-4ba6-a20d-604af2830d7b.png)|
>
> It appears to be caused by this:
> 
> ```html
> <picture>
>   <source
>     srcset="/img/microsoft-logo.png"
>     media="(prefers-color-scheme: dark)"
>   />
>   <img src="/img/microsoft-logo-inverted.png" height="20" alt="Microsoft" />
> </picture>
> ```
> 
> From: https://github.com/devcontainers/devcontainers.github.io/blob/bf07ad571b8966e5097ce4728fc5ad5da1f81062/_includes/footer.html#L32

Nothing else changes when dark mode is enabled, so this is the only thing that does. When it does, it makes it white-on-white which isn't readable.

The reason I removed the `<picture>` wrapper tag is just personal preference to not use stuff if it's not needed; and it doesn't seem to be needed when you only have one `<img>` and no `<source>` elements to provide alternatives 🤷‍♂️.