### PR TITLE
Added devcontainer-contrib templates collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -43,6 +43,11 @@
   contact: https://github.com/devcontainers-contrib/features/issues
   repository: https://github.com/devcontainers-contrib/features
   ociReference: ghcr.io/devcontainers-contrib/features
+- name: DevContainers-Contrib Templates
+  maintainer: Daniel Braun
+  contact: https://github.com/devcontainers-contrib/templates/issues
+  repository: https://github.com/devcontainers-contrib/templates
+  ociReference: ghcr.io/devcontainers-contrib/templates
 - name: Assorted Features
   maintainer: eitsupi
   contact: https://github.com/eitsupi/devcontainer-features/issues


### PR DESCRIPTION
Currently, this template collection contains a basic terraform template 😄 (main difference is that not azure-oriented like the current official terraform-azure template, and also exposes more versions as variables ) 