### PR TITLE
Adds mamba-org/devcontainer-features to the collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -213,3 +213,8 @@
   contact: https://github.com/withfig/features/issues
   repository: https://github.com/withfig/features
   ociReference: ghcr.io/withfig/features
+- name: Mamba Features
+  maintainer: mamba-org
+  contact: https://github.com/mamba-org/devcontainer-features/issues
+  repository: https://github.com/mamba-org/devcontainer-features
+  ociReference: ghcr.io/mamba-org/devcontainer-features


### PR DESCRIPTION
~~(The repository has just been transferred to mamba-org and the Feature release has not been completed, so it is in draft.)~~

-> Released.

cc @maresb @wolfv