### PR TITLE
Add Tailscale devcontainer feature

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -213,3 +213,8 @@
   contact: https://github.com/withfig/features/issues
   repository: https://github.com/withfig/features
   ociReference: ghcr.io/withfig/features
+- name: Tailscale devcontainer features
+  maintainer: DentonGentry
+  contact: https://github.com/tailscale/codespace/issues
+  repository: https://github.com/tailscale/codespace
+  ociReference: ghcr.io/tailscale/codespace/tailscale


### PR DESCRIPTION
Adds the Tailscale devcontainer feature. cc @DentonGentry
Depends on https://github.com/tailscale/codespace/pull/6/files to merge with a new devcontainer feature for Tailscale.