### PR TITLE
Features list : Omit listing deprecated Features

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 2.7.7p221
 
 BUNDLED WITH
-   2.3.24
+   2.3.26

--- a/features.html
+++ b/features.html
@@ -25,12 +25,14 @@ sectionid: collection-index-features
 
 {% for c in site.data.devcontainer-index.collections %}
     {% for f in c.features %}
-    <tr>
-        <td class="tg-0lax"><a rel="nofollow" href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
-        <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html  }}</td>
-        <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
-        <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>
-    </tr>
+        {% if f.deprecated != true %}
+            <tr>
+                <td class="tg-0lax"><a rel="nofollow" href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
+                <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html  }}</td>
+                <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
+                <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>
+            </tr>
+        {% endif %}
     {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
https://containers.dev/features lists `ghcr.io/eitsupi/devcontainer-features/just`. However, the Feature author has `deprecated` the Feature --> https://github.com/eitsupi/devcontainer-features/tree/main/src/just

This PR avoids listing such deprecated Features.

![image](https://user-images.githubusercontent.com/24955913/210661064-bde2bf21-d1fe-47b7-a7cf-fe49469ef29b.png)