### PR TITLE
Add csutter's lightweight templates

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -223,3 +223,8 @@
   contact: https://github.com/astronomer/devcontainer-features/issues
   repository: https://github.com/astronomer/devcontainer-features
   ociReference: ghcr.io/astronomer/devcontainer-features
+- name: Lightweight devcontainer templates
+  maintainer: csutter
+  contact: https://github.com/csutter/lightweight-devcontainer-templates/issues
+  repository: https://github.com/csutter/lightweight-devcontainer-templates
+  ociReference: ghcr.io/csutter/lightweight-devcontainer-templates


### PR DESCRIPTION
I've started work on a set of devcontainer templates that are similar to, but differently opinionated from the original templates in [devcontainers/templates](https://github.com/devcontainers/templates). In particular, they are intended to be very basic/lightweight/"batteries excluded", and use upstream images for their respective ecosystem instead of the custom ones used by the default templates.

I've been a little bit on the fence about adding these to the collection of available templates because VS Code currently puts them all into one big list without categorisation, and there may be a risk of less experienced users who would be better off with the original templates getting confused.

Would love to hear some thoughts and take it from there!