### PR TITLE
Remove pnpm by NicoVIII, it was moved to devcontainers-contrib

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -88,11 +88,6 @@
   contact: https://github.com/joshspicer/features/issues
   repository: https://github.com/joshspicer/features
   ociReference: ghcr.io/joshspicer/features
-- name: pnpm (requires npm)
-  maintainer: NicoVIII
-  contact: https://github.com/NicoVIII/devcontainer-features/issues
-  repository: https://github.com/NicoVIII/devcontainer-features
-  ociReference: ghcr.io/NicoVIII/devcontainer-features
 - name: PHP Features
   maintainer: Shyim
   contact: https://github.com/shyim/devcontainers-features/issues


### PR DESCRIPTION
Like discussed here, the pnpm feature was moved into devcontainers-contrib:
https://github.com/devcontainers-contrib/features/issues/265

The old entry can be removed from the index to avoid the duplicate listing of pnpm. The one in devcontainers-contrib should be used from now on.