### PR TITLE
Fix action - Update collection-index 

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -284,7 +284,7 @@
   repository: https://github.com/swift-server/swift-devcontainer-template
   ociReference: ghcr.io/swift-server/swift-devcontainer-template
 - name: Android SDK Tools and Apt packages
-  maintainer: @akhildevelops
+  maintainer: akhildevelops
   contact: https://github.com/akhildevelops/devcontainer-features/issues
   repository: https://github.com/akhildevelops/devcontainer-features
   ociReference: ghcr.io/akhildevelops/devcontainer-features


### PR DESCRIPTION
https://github.com/devcontainers/devcontainers.github.io/actions/runs/4196382156/jobs/7277279916#step:7:69
Looks like the yaml parser doesn't allow `@` as the first letter for any token, removing that to fix the action failures.
