### PR TITLE
Add trunk to collection index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -293,3 +293,8 @@
   contact: https://github.com/HamishWHC/cs3231-devcontainer/issues
   repository: https://github.com/HamishWHC/cs3231-devcontainer
   ociReference: ghcr.io/hamishwhc/cs3231-devcontainer
+- name: TRunk CLI Features (trunk.io)
+  maintainer: trunk-io
+  contact: https://github.com/trunk-io/devcontainer-feature/issues
+  repository: https://github.com/trunk-io/devcontainer-feature
+  ociReference: ghcr.io/trunk-io/devcontainer-feature


### PR DESCRIPTION
We recently created a new feature - https://github.com/trunk-io/devcontainer-feature and would like to add it to the index.