### PR TITLE
Add MultiversX / Rust templates (experimental)

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -298,3 +298,8 @@
   contact: https://github.com/trunk-io/devcontainer-feature/issues
   repository: https://github.com/trunk-io/devcontainer-feature
   ociReference: ghcr.io/trunk-io/devcontainer-feature
+- name: MultiversX Dev Container Templates
+  maintainer: MultiversX
+  contact: https://github.com/multiversx/mx-template-devcontainers/issues
+  repository: https://github.com/multiversx/mx-template-devcontainers
+  ociReference: ghcr.io/multiversx/mx-template-devcontainers


### PR DESCRIPTION
Register [**MultiversX**](https://docs.multiversx.com/) Dev Container templates in `collection-index.yml`. 

These templates (mainly for Rust Smart Contracts development on MultiversX) are work in progress :rocket: 