### PR TITLE
feat: adds sonikro devcontainer-feature repository to the collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -313,3 +313,8 @@
   contact: https://github.com/gickis/devcontainer-features/issues
   repository: https://github.com/gickis/devcontainer-features
   ociReference: ghcr.io/gickis/devcontainer-features
+- name: sonikro Dev Container Features
+  maintainer: Jonathan Nagayoshi
+  contact: https://github.com/sonikro/devcontainer-features/issues
+  repository: https://github.com/sonikro/devcontainer-features
+  ociReference: ghcr.io/sonikro/devcontainer-features


### PR DESCRIPTION
I started developing some useful DevContainer features. Right now I create one for Semgrep, and I'd like to make that available in the VSCode UI. So I wanted to add my repository to the collection