### PR TITLE
update maintainer name to 'The Dev Container Contrib Community'

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -39,12 +39,12 @@
   repository: https://github.com/mpriscella/features
   ociReference: ghcr.io/mpriscella/features
 - name: DevContainers-Contrib Features
-  maintainer: Daniel Braun
+  maintainer: The Dev Container Contrib Community
   contact: https://github.com/devcontainers-contrib/features/issues
   repository: https://github.com/devcontainers-contrib/features
   ociReference: ghcr.io/devcontainers-contrib/features
 - name: DevContainers-Contrib Templates
-  maintainer: Daniel Braun
+  maintainer: The Dev Container Contrib Community
   contact: https://github.com/devcontainers-contrib/templates/issues
   repository: https://github.com/devcontainers-contrib/templates
   ociReference: ghcr.io/devcontainers-contrib/templates


### PR DESCRIPTION
@danielbraun89 - I was looking through our index and saw that we're currently listing your name for the contributions to your awesome devcontainers-contrib repos! 

Please let me know if you'd like to keep it as-is, but I think it would be clearer to list these Features with something along the lines of 'The Dev Container Contrib Community'.  