### PR TITLE
Fix missing repository entry

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -330,5 +330,6 @@
   ociReference: ghcr.io/jasonthedeveloper/features
 - name: Templates by John Muchovej
   maintainer: John Muchovej
-  contact: https://github.com/jmuchovej/devcontainers
+  contact: https://github.com/jmuchovej/devcontainers/issues
+  repository: https://github.com/jmuchovej/devcontainers
   ociReference: ghcr.io/jmuchovej/templates


### PR DESCRIPTION
Forgot to add the `repository` link. https://github.com/devcontainers/devcontainers.github.io/pull/170#discussion_r1130168002