### PR TITLE
Add command runner

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -373,3 +373,8 @@
   contact: https://github.com/michidk/
   repository: https://github.com/michidk/devcontainers-features
   ociReference: ghcr.io/michidk/devcontainers-features
+- name: A powerful and handy feature that runs remote shell scripts
+  maintainer: Xiaowei Wang
+  contact: https://github.com/wxw-matt/devcontainer-features/issues
+  repository: https://github.com/wxw-matt/devcontainer-features
+  ociReference: ghcr.io/wxw-matt/devcontainer-features

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -378,3 +378,8 @@
   contact: https://github.com/wxw-matt/devcontainer-features/issues
   repository: https://github.com/wxw-matt/devcontainer-features
   ociReference: ghcr.io/wxw-matt/devcontainer-features
+- name: Run shell commands
+  maintainer: Xiaowei Wang
+  contact: https://github.com/wxw-matt/devcontainer-features/issues
+  repository: https://github.com/wxw-matt/devcontainer-features
+  ociReference: ghcr.io/wxw-matt/devcontainer-features


### PR DESCRIPTION
A feature that can run any valid shell commands. 
For example:
```jsonc
"ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
        "command1": "apt-get update -y",
        "command2": "apt-get install -y vim telnet",
	"command3": "rm -rf /var/lib/apt/lists/*"
}
```