### PR TITLE
Add sfdx-cli feature to index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -383,3 +383,8 @@
   contact: https://github.com/wxw-matt/devcontainer-features/issues
   repository: https://github.com/wxw-matt/devcontainer-features
   ociReference: ghcr.io/wxw-matt/devcontainer-features
+- name: Salesforce CLI Features
+  maintainer: Jason Vercellone
+  contact: https://github.com/vercellone/devcontainer-features/issues
+  repository: https://github.com/vercellone/devcontainer-features
+  ociReference: ghcr.io/vercellone/devcontainer-features


### PR DESCRIPTION
sfdx-cli feature installs the Salesforce CLI via the [Install the CLI with a TAR file](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm#sfdx_setup_install_cli_linux) method.