### PR TITLE
add devcontainers-community/templates to index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -403,3 +403,9 @@
   contact: https://github.com/favalos/devcontainer-features/issues
   repository: https://github.com/favalos/devcontainer-features
   ociReference: ghcr.io/favalos/devcontainer-features
+- name: Community Templates
+  maintainer: devcontainers-community
+  contact: https://github.com/devcontainers-community/templates/issues
+  repository: https://github.com/devcontainers-community/templates
+  ociReference: ghcr.io/devcontainers-community/templates
+


### PR DESCRIPTION
Index `devcontainers-community/templates`, created as an underwriter of a popular template in `microsoft/vscode-dev-containers` that is not already maintained.
Since `jupyter-datascience-notebooks` is currently ported, we can remove `jupyter-datascience-notebooks` from `microsoft/vscode-dev-containers` once this is merged.

cc @jcbhmr @nathancarter