### PR TITLE
Add official Julia language feature repo

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -528,3 +528,8 @@
   contact: https://github.com/Azure-Samples/python-ms-sql-devcontainer/issues
   repository: https://github.com/Azure-Samples/python-ms-sql-devcontainer
   ociReference: ghcr.io/azure-samples/python-ms-sql-devcontainer
+- name: Julia Language Features
+  maintainer: Julia Language Community
+  contact: https://github.com/JuliaLang/devcontainer-features/issues
+  repository: https://github.com/JuliaLang/devcontainer-features
+  ociReference: ghcr.io/julialang/devcontainer-features


### PR DESCRIPTION
CC @eitsupi, I think ideally you would merge https://github.com/eitsupi/devcontainer-features/pull/59 once this PR here is merged, right?

For background, there is a Julia feature in https://github.com/eitsupi/devcontainer-features at the moment, and that will be replaced with the feature in https://github.com/JuliaLang/devcontainer-features.