### PR TITLE
Point devcontainers-community/features and devcontainers-community/templates to the org itself, not empty monorepo

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -405,13 +405,13 @@
   ociReference: ghcr.io/favalos/devcontainer-features
 - name: Community Templates
   maintainer: devcontainers-community
-  contact: https://github.com/devcontainers-community/templates/issues
-  repository: https://github.com/devcontainers-community/templates
+  contact: https://github.com/orgs/devcontainers-community/discussions
+  repository: https://github.com/devcontainers-community
   ociReference: ghcr.io/devcontainers-community/templates
 - name: Community Features
   maintainer: devcontainers-community
-  contact: https://github.com/devcontainers-community/features/issues
-  repository: https://github.com/devcontainers-community/features
+  contact: https://github.com/orgs/devcontainers-community/discussions
+  repository: https://github.com/devcontainers-community
   ociReference: ghcr.io/devcontainers-community/features
 - name: Community npm Features
   maintainer: devcontainers-community


### PR DESCRIPTION
reason: want to remove the stub repos https://github.com/devcontainers-community/features and https://github.com/devcontainers-community/templates links since they don't do much and instead point to the over-arching project @devcontainers-community org. unsure if "repository" can mean a non-git link (like `https://github.com/devcontainers-community`) or if it MUST be a git repo.