### PR TITLE
Edit pass for consistency

### DIFF
--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -6,7 +6,7 @@ author: Microsoft
 index: 9
 ---
 
-We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
+We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. We also welcome you to join our [community Slack channel](https://aka.ms/dev-container-community).
 
 ## <a href="#contribution-approaches" name="contribution-approaches" class="anchor"> Contribution approaches </a>
 

--- a/_implementors/features-distribution.md
+++ b/_implementors/features-distribution.md
@@ -8,7 +8,7 @@ index: 6
 
 **TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get started on distributing your own Dev Container Features.**
 
-This specification defines a pattern where community members and organizations can author and self-publish [Dev Container 'Features'](../features). 
+This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Features](../features). 
 
 Goals include:
 
@@ -89,7 +89,7 @@ Each Features's `devcontainer-feature.json` metadata file is appended into the `
 
 There are several supported ways to distribute Features. Distribution is handled by the implementing packaging tool such as the [Dev Container CLI](https://github.com/devcontainers/cli) or [Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish). See the [quick start repository](https://github.com/devcontainers/feature-template) for a full working example.
 
-A user references a distributed Feature in a `devcontainer.json` as defined in ['referencing a feature'](../features#referencing-a-feature).
+A user references a distributed Feature in a `devcontainer.json` as defined in ['referencing a Feature'](../features#referencing-a-feature).
 
 ### <a href="#oci-registry" name="oci-registry" class="anchor"> OCI Registry </a>
 
@@ -151,7 +151,7 @@ Additional constraints exists when including local Features in a project:
 
 * The project must have a `.devcontainer/` folder at the root of the [**project workspace folder**](/implementors/spec/#project-workspace-folder).
 
-* A local Feature's source code **must** be contained within a sub-folder of the `.devcontainer/ folder`.
+* A local Feature's source code **must** be contained within a sub-folder of the `.devcontainer/` folder.
 
 * The sub-folder name **must** match the Feature's `id` field.
 

--- a/_implementors/features.md
+++ b/_implementors/features.md
@@ -6,13 +6,13 @@ author: Microsoft
 index: 5
 ---
 
-Development container "Features" are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "Features" into your development container for you or your collaborators to use.
+**Development Container Features** are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "features" into your development container for you or your collaborators to use.
 
 Feature metadata is captured by a `devcontainer-feature.json` file in the root folder of the feature.
 
 > **Note:** While Features may be installed on top of any base image, the implementation of a Feature might restrict it to a subset of possible base images. For example, some Features may be authored to work with a certain Linux distro (e.g. debian-based images that use the `apt` package manager).
 > 
-> This section covers details on the Features specification. If you are looking for summarized information on creating your own Features, check out the [quick start](https://github.com/devcontainers/feature-starter) and [core Features](https://github.com/devcontainers/features) repositories.
+> This page covers details on the Features specification. If you are looking for summarized information on creating your own Features, check out the [quick start](https://github.com/devcontainers/feature-starter) and [core Features](https://github.com/devcontainers/features) repositories.
 
 ## <a href="#folder-structure" name="folder-structure" class="anchor"> Folder Structure </a>
 
@@ -72,7 +72,7 @@ The following lifecycle hooks may be declared as properties of `devcontainer-fea
 | `postAttachCommand` | [string, array, object](/implementors/json_reference#formatting-string-vs-array-properties) |
 {: .table .table-bordered .table-responsive}
 
-#### Behavior
+#### <a href="#behavior" name="behavior" class="anchor"> Behavior </a>
 
 Each property mirrors the behavior of the matching property in [`devcontainer.json`](/implementors/json_reference#Lifecycle-scripts), including the behavior that commands are executed from the context of the [project workspace folder](/implementors/spec/#project-workspace-folder).
 
@@ -80,7 +80,7 @@ For each lifecycle hook (in [Feature installation order](/implementors/features/
 
 If a Feature provides a given command with the [object syntax](/implementors/json_reference#formatting-string-vs-array-properties), all commands within that group are executed in parallel, but still blocking commands from subsequent Features and/or the `devcontainer.json`.
 
-> NOTE: These properties are stored within [image metadata](/implementors/spec/#merge-logic).
+> **Note**: These properties are stored within [image metadata](/implementors/spec/#merge-logic).
 
 ### <a href="#options-property" name="options-property" class="anchor"> The `options` property </a>
 
@@ -117,11 +117,11 @@ Feature scripts run as the `root` user and sometimes need to know which user acc
 
 Additionally, the home folders of the two users are passed to the Feature scripts as `_REMOTE_USER_HOME` and `_CONTAINER_USER_HOME` environment variables.
 
-The container user can be set with `containerUser` in the devcontainer.json and image metadata, `user` in the docker-compose.yml, `USER` in the Dockerfile, and can be passed down from the base image.
+The container user can be set with `containerUser` in the `devcontainer.json` and image metadata, `user` in the `docker-compose.yml`, `USER` in the Dockerfile, and can be passed down from the base image.
 
 ### <a href="#dev-container-id" name="dev-container-id" class="anchor"> Dev Container ID </a>
 
-An identifier will be referred to as `${devcontainerId}` in the devcontainer.json and the Feature metadata and that will be replaced with the dev container's id. It should only be used in parts of the configuration and metadata that is not used for building the image because that would otherwise prevent pre-building the image at a time when the dev container's id is not known yet. Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the Feature metadata are: `entrypoint`, `mounts`, `customizations`.
+An identifier will be referred to as `${devcontainerId}` in the `devcontainer.json` and the Feature metadata and that will be replaced with the dev container's id. It should only be used in parts of the configuration and metadata that is not used for building the image because that would otherwise prevent pre-building the image at a time when the dev container's id is not known yet. Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the Feature metadata are: `entrypoint`, `mounts`, `customizations`.
 
 Implementations can choose how to compute this identifier. They must ensure that it is unique among other dev containers on the same Docker host and that it is stable across rebuilds of dev containers. The identifier must only contain alphanumeric characters. We describe a way to do this below.
 
@@ -218,7 +218,7 @@ As a shorthand, the value of the `features` property can be provided as a single
 }
 ```
 
-### <a href="#referencing-a-feature" name="referencing-a-feature" class="anchor"> Referencing a feature </a>
+### <a href="#referencing-a-feature" name="referencing-a-feature" class="anchor"> Referencing a Feature </a>
 
 The `id` format specified dicates how a supporting tool will locate and download a given feature. `id` is one of the following:
 
@@ -251,7 +251,7 @@ If the Feature is included in a folder as part of the repository that contains `
 
 ## <a href="#release" name="release" class="anchor"> Release </a>
 
-_For information on distributing Features, see [the dev container Features distribution page](../features-distribution)._
+_For information on distributing Features, see the [Features distribution page](../features-distribution)._
 
 ## <a href="#execution" name="execution" class="anchor"> Execution </a>
 
@@ -313,11 +313,11 @@ After `overrideFeatureInstallOrder` is resolved, any remaining Features that dec
 
 ### <a href="#option-resolution" name="option-resolution" class="anchor"> Option Resolution </a>
 
-A Feature's 'options' - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables.
+A Feature's options - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables.
 
 A supporting tool will parse the `options` object provided by the user.  If a value is provided for a Feature, it will be emitted to a file named `devcontainer-features.env` following the format `<OPTION_NAME>=<value>`.  
 
-To ensure a option that is valid as an environment variable, the follow substitutions are performed.
+To ensure a option that is valid as an environment variable, the follow substitutions are performed:
 
 ```javascript
 (str: string) => str

--- a/_implementors/features.md
+++ b/_implementors/features.md
@@ -313,7 +313,7 @@ After `overrideFeatureInstallOrder` is resolved, any remaining Features that dec
 
 ### <a href="#option-resolution" name="option-resolution" class="anchor"> Option Resolution </a>
 
-A Feature's options - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables.
+A Feature's `options` - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables.
 
 A supporting tool will parse the `options` object provided by the user.  If a value is provided for a Feature, it will be emitted to a file named `devcontainer-features.env` following the format `<OPTION_NAME>=<value>`.  
 

--- a/_implementors/reference.md
+++ b/_implementors/reference.md
@@ -6,18 +6,18 @@ author: Microsoft
 index: 2
 ---
 
-The reference implementation for the specification is available through a [development container CLI](https://github.com/devcontainers/cli). This CLI can take a devcontainer.json and create and configure a dev container from it.
+The reference implementation for the specification is available through a [development container CLI](https://github.com/devcontainers/cli). This CLI can take a `devcontainer.json` and create and configure a dev container from it.
 
-## <a href="#what-is-CLI" name="what-is-CLI" class="anchor"> What is the dev container CLI? </a>
-When tools like VS Code and Codespaces detect a devcontainer.json file in a user's project, they use a CLI to configure a dev container. We've now opened up this CLI as a reference implementation so that individual users and other tools can read in devcontainer.json metadata and create dev containers from it.
+## <a href="#what-is-CLI" name="what-is-CLI" class="anchor"> What is the Dev Container CLI? </a>
+When tools like VS Code and Codespaces detect a `devcontainer.json` file in a user's project, they use a CLI to configure a dev container. We've now opened up this CLI as a reference implementation so that individual users and other tools can read in `devcontainer.json` metadata and create dev containers from it.
 
 This CLI can either be used directly or integrated into product experiences, similar to how it's integrated with Dev Containers and Codespaces today. It currently supports both a simple single container option and integrates with [Docker Compose](https://docs.docker.com/compose/) for multi-container scenarios.
 
-The CLI is available for review in a new [devcontainers/cli](https://github.com/devcontainers/cli) repository, and you can read more about its development in [this issue](https://github.com/devcontainers/spec/issues/9) in the spec repo.
+The CLI is available in the [devcontainers/cli](https://github.com/devcontainers/cli) repository.
 
 ## <a href="#try-it" name="try-it" class="anchor"> How can I try it? </a>
 
-We'd love for you to try out the dev container CLI and let us know what you think. You can quickly try it out in just a few simple steps, either by installing its npm package or building the CLI repo from sources.
+We'd love for you to try out the Dev Container CLI and let us know what you think. You can quickly try it out in just a few simple steps, either by installing its npm package or building the CLI repo from sources.
 
 You may learn more about building from sources in the [CLI repo's README](https://github.com/devcontainers/cli#try-it-out). On this page, we'll focus on using the npm package.
 
@@ -97,7 +97,7 @@ Hello, VS Code Remote - Containers!
 {"outcome":"success"}
 ```
 
-Congrats, you've just run the dev container CLI and seen it in action!
+Congrats, you've just run the Dev Container CLI and seen it in action!
 
 These steps are also provided in the CLI repo's [README](https://github.com/devcontainers/cli/blob/main/README.md). You may also review frequently asked questions [here](https://github.com/devcontainers/spec/issues/31).
 
@@ -110,13 +110,15 @@ We recommend using the [Dev Container CLI](#npm-install) (or other spec supporti
 devcontainer build --workspace-folder . --push true --image-name <my_image_name>:<optional_image_version>
 ```
 
+You can also check out our [in-depth guide on prebuilds](/_posts/2023-08-22-prebuild.md).
+
 #### <a href="#labels" name="labels" class="anchor"> Metadata in image labels</a> 
 
 You can include Dev Container configuration and Feature metadata in prebuilt images via [image labels](https://docs.docker.com/config/labels-custom-metadata/). This makes the image self-contained since these settings are automatically picked up when the image is referenced - whether directly, in a `FROM` in a referenced Dockerfile, or in a Docker Compose file. This helps prevent your Dev Container config and image contents from getting out of sync, and allows you to push updates of the same configuration to multiple repositories through a simple image reference.
 
-This metadata label is **automatically added** when you pre-build using the [Dev Container CLI](#npm-install) (or other spec supporting utilities like the [GitHub Action](https://github.com/marketplace/actions/devcontainers-ci) or [Azure DevOps task](https://marketplace.visualstudio.com/items?itemName=devcontainers.ci)) and includes settings from devcontainer.json and any referenced Dev Container Features.
+This metadata label is **automatically added** when you pre-build using the [Dev Container CLI](#npm-install) (or other spec supporting utilities like the [GitHub Action](https://github.com/marketplace/actions/devcontainers-ci) or [Azure DevOps task](https://marketplace.visualstudio.com/items?itemName=devcontainers.ci)) and includes settings from `devcontainer.json` and any referenced Dev Container Features.
 
-This allows you to have a separate **more complex** devcontainer.json you use to pre-build your image, and then a dramatically **simplified one** in one or more repositories. The contents of the image will be merged with this simplified devcontainer.json content at the time you create the container (see the [the spec](/implementors/spec/#merge-logic) for info on merge logic). But at its simplest, you can just reference the image directly in devcontainer.json for the settings to take effect:
+This allows you to have a separate **more complex** `devcontainer.json` you use to pre-build your image, and then a dramatically **simplified one** in one or more repositories. The contents of the image will be merged with this simplified devcontainer.json content at the time you create the container (see the [the spec](/implementors/spec/#merge-logic) for info on merge logic). But at its simplest, you can just reference the image directly in `devcontainer.json` for the settings to take effect:
 
 ```json
 {
@@ -138,7 +140,7 @@ See the [Dev Container metadata reference](../json_reference) for information on
 
 ### <a href="#domainnames" name="domainnames" class="anchor"> Domain Names </a> 
 
-If you are behind a firewall that needs to allow specific domains used by the dev container CLI, here's the list of hostnames you should allow communication to go through:
+If you are behind a firewall that needs to allow specific domains used by the Dev Container CLI, here's the list of hostnames you should allow communication to go through:
 
 * `containers.dev` - The [homepage](https://containers.dev/) for everything about dev containers. It includes all official and community-supported [Features](https://containers.dev/features) and [Templates](https://containers.dev/templates).
 * `ghcr.io`, `*.azurecr.io`, `mcr.microsoft.com` - [OCI registries](https://containers.dev/implementors/features-distribution/#oci-registry) like [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry), [Azure Container Registry](azure.microsoft.com/en-us/products/container-registry), and [Microsoft Container Registry](https://mcr.microsoft.com/en-us/catalog?search=dev%20container) serves as the primary distribution mechanism for dev container resources. 

--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -6,19 +6,19 @@ author: Microsoft
 index: 1
 ---
 
-The purpose of the **development container** specification is to provide a way to enrich containers with the content and metadata necessary to enable development inside them. These container **environments** should be easy to use, create, and recreate. 
+The purpose of the **Development Container Specification** is to provide a way to enrich containers with the content and metadata necessary to enable development inside them. These container **environments** should be easy to use, create, and recreate. 
 
-A **development container** is a container in which a user can develop an application.  Tools that want to implement this specification should provide a set of features/commands that give more flexibility to users and allow **development containers** to scale to large development groups.
+A **development container** is a container in which a user can develop an application. Tools that want to implement this specification should provide a set of features/commands that give more flexibility to users and allow **development containers** to scale to large development groups.
 
 An **environment** is defined as a logical instance of one or more **development containers**, along with any needed side-car containers. An environment is based on one set of metadata that can be managed as a single unit. Users can create multiple **environments** from the same configuration metadata for different purposes.
 
 # <a href="#metadata" name="metadata" class="anchor"> Metadata </a>
 
-**Development containers** allow one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development and you may need to use different secrets or other settings. 
+Development containers allow one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development and you may need to use different secrets or other settings. 
 
 Furthermore, working inside a development container can require additional **metadata** to drive tooling or service experiences than you would normally need with a production container. Providing a structured and consistent form for this metadata is a core part of this specification.
 
-A **development container** is composed of a definition (e.g. contained in a `devcontainer.json` file) that deterministically creates containers under the control of the user.
+A development container is composed of a definition (e.g. contained in a `devcontainer.json` file) that deterministically creates containers under the control of the user.
 
 ## <a href="#devcontainerjson" name="devcontainerjson" class="anchor"> `devcontainer.json` </a>
 
@@ -34,7 +34,7 @@ It is valid that these files may exist in more than one location, so consider pr
 
 Certain dev container metadata properties can be stored in an image label as an array of metadata snippets. This allows them to be stored in prebuilt images, such that, the image and its related configuration are self-contained. These contents should then be merged with any local devcontainer.json file contents at the time the container is created. An array is used so subsequent image builds can simply append changes to the array rather than attempting to merge at that point - which improves compatibility with arbitrary image build systems.
 
-Metadata should be representative of with the following structure, using one entry per [Dev Container Feature](../features) and devcontainer.json (see table below for the full list):
+Metadata should be representative of with the following structure, using one entry per [Dev Container Feature](../features) and `devcontainer.json` (see table below for the full list):
 
 ```json
 [
@@ -61,7 +61,7 @@ The metadata is added to the image as a `devcontainer.metadata` label with a JSO
 
 ### <a href="#merge-logic" name="merge-logic" class="anchor"> Merge Logic </a>
 
-To apply the metadata together with a user's devcontainer.json at runtime, the following merge logic by property is used. The table also notes which properties are currently supported coming from the devcontainer.json and from the Feature metadata- this will change over time as we add more properties.
+To apply the metadata together with a user's `devcontainer.json` at runtime, the following merge logic by property is used. The table also notes which properties are currently supported coming from the `devcontainer.json` and from the Feature metadata- this will change over time as we add more properties.
 
 | Property | Type/Format | Merge Logic | devcontainer.json | devcontainer-feature.json |
 | -------- | ----------- | ----------- | :---------------: | :--------------: |
@@ -93,13 +93,13 @@ To apply the metadata together with a user's devcontainer.json at runtime, the f
 | `hostRequirements` | `cpus`, `memory`, `storage`, `gpu` | Max value wins. | ✓ |   |
 {: .table .table-bordered .table-responsive}
 
-Variables in string values will be substituted at the time the value is applied. When the order matters, the devcontainer.json is considered last.
+Variables in string values will be substituted at the time the value is applied. When the order matters, the `devcontainer.json` is considered last.
 
 ### <a href="#metadata-notes" name="metadata-notes" class="anchor"> Notes </a>
 
 - Passing the label as a `LABEL` instruction in the Dockerfile:
 	- The size limit on Dockerfiles is around 1.3MB. The line length is limited to 65k characters.
-	- Using one line per feature should allow for making full use of these limits.
+	- Using one line per Feature should allow for making full use of these limits.
 - Passing the label as a command line argument:
 	- There is no size limit documented for labels, but the daemon returns an error when the request header is >500kb.
 	- The 500kb limit is shared, so we cannot use a second label in the same build to avoid it.
@@ -117,7 +117,7 @@ Image based configurations only reference an image that should be reachable and 
 
 ## <a href="#dockerfile-based" name="dockerfile-based" class="anchor"> Dockerfile based </a>
 
-These configurations are defined as using a `Dockerfile` to define the starting point of the **development containers**. As with image based configurations, it is assumed that any base images are already reachable by **Docker** when performing a `docker build` command. The only required parameter in this case is the relative reference to the `Dockerfile` in `build.dockerfile`. The details are [here](../json_reference#image-specific).
+These configurations are defined as using a Dockerfile to define the starting point of the development containers. As with image based configurations, it is assumed that any base images are already reachable by Docker when performing a `docker build` command. The only required parameter in this case is the relative reference to the Dockerfile in `build.dockerfile`. The details are [here](../json_reference#image-specific).
 
 There are multiple properties that allow users to control how `docker build` works:
 
@@ -134,11 +134,11 @@ Docker Compose configurations use `docker-compose` (which may be Docker Compose 
 - `service`: declares the **main** container that will be used for all other operations. Tools are assumed to also use this parameter to connect to the **development container**, although they can provide facilities to connect to the other containers as required by the user.
 - `runServices`: an optional property that indicates the set of services in the `docker-compose` configuration that should be started or stopped with the environment.
 
-It is important to note that **image** and **dockerfile** properties are not needed since Docker Compose supports them natively in the format. 
+It is important to note that the `image` and `dockerfile` properties are not needed since Docker Compose supports them natively in the format. 
 
 # <a href="#other-options" name="other-options" class="anchor"> Other options </a>
 
-In addition to the configuration options explained above, there are other settings that apply when creating **development containers** to facilitate their use by developers. 
+In addition to the configuration options explained above, there are other settings that apply when creating development containers to facilitate their use by developers. 
 
 A complete list of available metadata properties and their purposes can be found in the [`devcontainer.json` reference](https://aka.ms/devcontainer.json). However, we will describe the critical ones below in more detail.
 
@@ -146,28 +146,28 @@ A complete list of available metadata properties and their purposes can be found
 
 Development container "Features" are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "features" into your development container for you or your collaborators to use.
 
-They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [features documentation](../features) for more details.
+They are applied to container images as a secondary build step and can affect a number of dev container configuration settings. See the [Features documentation](../features) for more details.
 
 ## <a href="#environment-variables" name="environment-variables" class="anchor"> Environment variables </a>
 
-Environment variables can be set at different points in the dev container lifecycle. With this in mind, **development containers** support two classes of environment variables:
+Environment variables can be set at different points in the dev container lifecycle. With this in mind, development containers support two classes of environment variables:
 
 * **Container**: These variables are part of the container when it is created and are available at all points in its lifecycle. This concept is native to containers and can be set in the container image itself, using `containerEnv` for **image** and **Dockerfile** scenarios or using orchestrator specific properties like `env` in **Docker Compose** files.
-* **Remote**: These variables should be set by a **development container** supporting tool as part of configuring its runtime environment. Users can set these using the `remoteEnv` property and implementing tools or services may add their own for specific scenarios (e.g., secrets). These variables can change during the lifetime of the container, and are added after the container's `ENTRYPOINT` has fired.
+* **Remote**: These variables should be set by a development container supporting tool as part of configuring its runtime environment. Users can set these using the `remoteEnv` property and implementing tools or services may add their own for specific scenarios (e.g., secrets). These variables can change during the lifetime of the container, and are added after the container's `ENTRYPOINT` has fired.
 
 The reason for this separation is it allows for the use of information not available at image build time and simplifies updating the environment for project/repository specific needs without modifying an image. With this in in mind, it's important to note that implementing tools should also support the [dynamic variable syntax](../json_reference/#variables-in-devcontainerjson) described in the metadata reference document.
 
-Another notable and important environment variable related property is **`userEnvProbe`**. Implementing tools should use this property to "probe" for expected environment variables using the specified type of shell. However, it does not specify that this type of shell needs to be used for all sub-processes (given the performance impact). Instead, "probed" environment variables should be merged with Remote environment variables for any processes the implementer injects after the container is created.  This allows implementors to emulate developer expected behaviors around values added to their profile and rc files. 
+Another notable and important environment variable related property is **`userEnvProbe`**. Implementing tools should use this property to "probe" for expected environment variables using the specified type of shell. However, it does not specify that this type of shell needs to be used for all sub-processes (given the performance impact). Instead, "probed" environment variables should be merged with remote environment variables for any processes the implementer injects after the container is created.  allows implementors to emulate developer expected behaviors around values added to their profile and rc files. 
 
 ## <a href="#mounts" name="mounts" class="anchor"> Mounts </a>
 
-Mounts allow containers to have access to the underlying machine, share data between containers and to persist information between **development containers**. 
+Mounts allow containers to have access to the underlying machine, share data between containers and to persist information between development containers. 
 
 A default mount should be included so that the source code is accessible from inside the container. Source code is stored outside of the container so that a developer's in-flight edits can be extracted, or a new container created in the event a container no longer starts.
 
 ## <a href="#workspace-folder" name="workspace-folder" class="anchor"> workspaceFolder and workspaceMount </a>
 
-The default mount point for the source code can be set with the `workspaceMount` property for **image** and **dockerfile** scenarios or using the built in `mounts` property in **Docker Compose** files. This folder should point to the root of a repository (where the `.git` folder is found) so that source control operations work correctly inside the container.
+The default mount point for the source code can be set with the `workspaceMount` property for image and Dockerfile scenarios or using the built in `mounts` property in Docker Compose files. This folder should point to the root of a repository (where the `.git` folder is found) so that source control operations work correctly inside the container.
 
 The `workspaceFolder` can then be set to the default folder inside the container that should used in the container. Typically this is either the mount point in the container, or a sub-folder under it. Allowing a sub-folder to be used is particularly important for monorepos given you need the `.git` folder to interact with source control but developers are typically are interacting with a specific sub-project within the overall repository. 
 
@@ -193,7 +193,7 @@ A development environment goes through different lifecycle events during its use
 
 ## <a href="#configuration-validation" name="configuration-validation" class="anchor"> Configuration Validation </a>
 
-The exact steps required to validate configuration can vary based on exactly where the **development container** metadata is persisted. However, when considering a `devcontainer.json` file, the following validation should occur:
+The exact steps required to validate configuration can vary based on exactly where the development container metadata is persisted. However, when considering a `devcontainer.json` file, the following validation should occur:
 
 1. Validate that a workspace source folder has been provided. It is up to the implementing tool to determine what to do if no source folder is provided.
 2. Search for a `devcontainer.json` file in one of the locations [above](#devcontainerjson) in the workspace source folder. 
@@ -212,7 +212,7 @@ During this step, the following is executed:
 
 ### <a href="#image-creation" name="image-creation" class="anchor"> Image Creation </a> 
 
-The first part of environment creation is generating the final image(s) that the **development containers** are going to use. This step is orchestrator dependent and can consist of just pulling a Docker image, running Docker build, or docker-compose build. Additionally, this step is useful on its own since it permits the creation of intermediate images that can be uploaded and used by other users, thus cutting down on creation time. It is encouraged that tools implementing this specification give access to a command that just executes this step.
+The first part of environment creation is generating the final image(s) that the development containers are going to use. This step is orchestrator dependent and can consist of just pulling a Docker image, running Docker build, or `docker-compose` build. Additionally, this step is useful on its own since it permits the creation of intermediate images that can be uploaded and used by other users, thus cutting down on creation time. It is encouraged that tools implementing this specification give access to a command that just executes this step.
 
 This step executes the following tasks:
 
@@ -260,7 +260,7 @@ The intention of this step is to ensure all containers are stopped correctly bas
 
 ## <a href="#environment-resume" name="environment-resume" class="anchor"> Environment Resume </a>
 
-While it is not a strict requirement to keep a **development container** after it has been stopped, this is the most common scenario.
+While it is not a strict requirement to keep a development container after it has been stopped, this is the most common scenario.
 
 To resume the environment from a stopped state:
 1. Restart all related containers.

--- a/_implementors/spec.md
+++ b/_implementors/spec.md
@@ -14,7 +14,7 @@ An **environment** is defined as a logical instance of one or more **development
 
 # <a href="#metadata" name="metadata" class="anchor"> Metadata </a>
 
-Development containers allow one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development and you may need to use different secrets or other settings. 
+The Development Container Spec allows one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development and you may need to use different secrets or other settings. 
 
 Furthermore, working inside a development container can require additional **metadata** to drive tooling or service experiences than you would normally need with a production container. Providing a structured and consistent form for this metadata is a core part of this specification.
 

--- a/_implementors/templates-distribution.md
+++ b/_implementors/templates-distribution.md
@@ -68,7 +68,7 @@ Templates are distributed as tarballs. The tarball contains the entire contents 
 
 The tarball is named `devcontainer-template-<id>.tgz`, where `<id>` is the Templates's `id` field.
 
-A reference implementation for packaging and distributing Templates is provided as a GitHub Action (https://github.com/devcontainers/action).
+A reference implementation for packaging and distributing Templates is provided as a [GitHub Action](https://github.com/devcontainers/action).
 
 ### <a href="#devcontainer-collection" name="devcontainer-collection" class="anchor"> devcontainer-collection.json </a>
 
@@ -135,7 +135,7 @@ oras push ${REGISTRY}/${NAMESPACE}:latest \
 
 ## <a href="#guide-to-publishing-templates" name="guide-to-publishing-templates" class="anchor">Guide to publishing Templates</a>
 
-The dev container CLI can be used to publish [Dev Container Template](https://containers.dev/implementors/templates/) artifacts to an OCI registry (that supports the [artifacts specification](https://oras.land/implementors/)).
+The Dev Container CLI can be used to publish [Template](https://containers.dev/implementors/templates/) artifacts to an OCI registry (that supports the [artifacts specification](https://oras.land/implementors/)).
 
 To see all the available options, run `devcontainers templates publish --help`.
 

--- a/_implementors/templates.md
+++ b/_implementors/templates.md
@@ -6,7 +6,7 @@ author: Microsoft
 index: 7
 ---
 
-Development container "Templates" are source files packaged together that encode configuration for a complete development environment. A Template can be used in a new or existing project, and a [supporting tool](/supporting) will use the configuration from the Template to build a development container.
+**Development Container Templates** are source files packaged together that encode configuration for a complete development environment. A Template can be used in a new or existing project, and a [supporting tool](/supporting) will use the configuration from the Template to build a development container.
 
 The configuration is placed in a [`.devcontainer.json`](/implementors/json_reference#devcontainerjson) which can also reference other files within the Template. Alternatively, `.devcontainer/devcontainer.json` can also be used if the container needs to reference other files, such as a `Dockerfile` or `docker-compose.yml`. A Template can also provide additional source files (eg: boilerplate code or a [lifecycle script](/implementors/json_reference/#lifecycle-scripts)).
 

--- a/collections.html
+++ b/collections.html
@@ -6,13 +6,16 @@ sectionid: collection-index
 
 <h1 style="margin-left: auto;margin-right: auto;">Collections</h1>
 <p style="margin-left: auto;margin-right: auto;">
-    This list below contains pointers to official and community-contributed Dev Container assets, including Features and Templates.
-    Collections on this list are continuously crawled for liveness, and can be presented in UX of Dev Container-supporting tools 
+    This list below contains pointers to official and community-contributed dev container assets, including Features and
+    Templates.
+    Collections on this list are continuously crawled for liveness, and can be presented in UX of spec supporting tools
     (i.e. it will be presented in the GitHub Codespaces and VS Code Dev Containers UX).
 </p>
 
 <p>
-    To add your own collection to this list, please create a PR editing <a href="https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml">this yaml file</a>.
+    To add your own collection to this list, please create a PR editing <a
+        href="https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml">this
+        yaml file</a>.
 </p>
 <tr>
     <td class="tg-0lax"><b>Name</b></b></td>
@@ -23,7 +26,8 @@ sectionid: collection-index
 {% for c in site.data.collection-index %}
 <tr>
     <td class="tg-0lax">{{ c.name }}</td>
-    <td class="tg-0lax"><a rel="nofollow" href="{{ c.contact | strip_html  }}">{{ c.maintainer | strip_html  }}</a></td>
-    <td class="tg-0lax"><a rel="nofollow" href="{{ c.repository | strip_html  }}">{{ c.repository | strip_html  }}</a></td>
+    <td class="tg-0lax"><a rel="nofollow" href="{{ c.contact | strip_html  }}">{{ c.maintainer | strip_html }}</a></td>
+    <td class="tg-0lax"><a rel="nofollow" href="{{ c.repository | strip_html  }}">{{ c.repository | strip_html }}</a>
+    </td>
 </tr>
 {% endfor %}

--- a/features.html
+++ b/features.html
@@ -7,11 +7,13 @@ sectionid: collection-index-features
 <h1 style="margin-left: auto;margin-right: auto;">Available Dev Container Features</h1>
 <p style="margin-left: auto;margin-right: auto;">
     This table contains all official and community-supported <a href="implementors/features/">Dev Container Features</a>
-    known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously 
-    updated with the latest available feature information. See the <a href="https://github.com/devcontainers/feature-template">
-    Feature quick start repository</a> to add your own!
+    known at the time of crawling <a href="collections">each registered collection</a>. This list is continuously
+    updated with the latest available feature information. See the <a
+        href="https://github.com/devcontainers/feature-template">
+        Feature quick start repository</a> to add your own!
     <br><br>
-    <a href="implementors/features#referencing-a-feature">Referencing a feature</a> below can be done in the "features" section of a devcontainer.json.
+    <a href="implementors/features#referencing-a-feature">Referencing a Feature</a> below can be done in the "features"
+    section of a devcontainer.json.
     <br><br>
     Please note that if you need to report a Feature, you should do so through the registry hosting the Feature.
 </p>
@@ -26,15 +28,16 @@ sectionid: collection-index-features
 </tr>
 
 {% for c in site.data.devcontainer-index.collections %}
-    {% for f in c.features %}
-        {% if f.deprecated != true %}
-            <tr>
-                <td class="tg-0lax"><a rel="nofollow" href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html  }}</a></td>
-                <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html  }}</td>
-                <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
-                <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>
-            </tr>
-        {% endif %}
-    {% endfor %}
+{% for f in c.features %}
+{% if f.deprecated != true %}
+<tr>
+    <td class="tg-0lax"><a rel="nofollow" href="{{ f.documentationURL | strip_html }}">{{ f.name | strip_html }}</a>
+    </td>
+    <td class="tg-0lax">{{ c.sourceInformation.maintainer | strip_html }}</td>
+    <td class="tg-0lax"><code>{{ f.id | strip_html  }}:{{ f.majorVersion | strip_html }}</code></td>
+    <td class="tg-0lax"><code>{{ f.version | strip_html  }}</code></td>
+</tr>
+{% endif %}
+{% endfor %}
 
 {% endfor %}

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@ layout: default
 
         <br />
         <div class="intro-text">
-            <a class="github-button" href="https://github.com/devcontainers/spec" data-size="large" data-icon="octicon-star" data-show-count="true" tabindex="0"
+            <a class="github-button" href="https://github.com/devcontainers/spec" data-size="large"
+                data-icon="octicon-star" data-show-count="true" tabindex="0"
                 aria-label="Star devcontainers/spec on GitHub">Star</a>
         </div>
     </div>
@@ -27,44 +28,61 @@ layout: default
         <div class="col-lg-7" role="navigation" aria-label="Main">
             <h2 class="header-light regular-pad">What are Development Containers?</h2>
 
-            <p>A Development Container (or Dev Container for short) allows you to use a container as a full-featured development environment. It can be used to run an application, to separate tools, libraries, or runtimes needed for working with a codebase, and to aid in continuous integration and testing. Dev containers can be run locally or remotely, in a private or public cloud, in a variety of <a href="./supporting" aria-label="Supporting tools">supporting tools and editors</a>.</p>
+            <p>A development container (or dev container for short) allows you to use a container as a full-featured
+                development environment. It can be used to run an application, to separate tools, libraries, or runtimes
+                needed for working with a codebase, and to aid in continuous integration and testing. Dev containers can
+                be run locally or remotely, in a private or public cloud, in a variety of <a href="./supporting"
+                    aria-label="Supporting tools">supporting tools and editors</a>.</p>
 
-            <p>The Development Containers Specification seeks to find ways to enrich existing formats with common development specific settings, tools, and configuration while still providing a simplified, un-orchestrated single container option – so that they can be used as coding environments or for continuous integration and testing. Beyond the specification's core metadata, the spec also enables developers to quickly share and reuse container setup steps through <a href="./features" aria-label="See the Dev Container Features spec">Dev Container Features</a> and <a href="./templates" aria-label="See the Dev Container Templates spec">Templates</a>. </p>
+            <p>The Development Container Specification seeks to find ways to enrich existing formats with common
+                development specific settings, tools, and configuration while still providing a simplified,
+                un-orchestrated single container option – so that they can be used as coding environments or for
+                continuous integration and testing. Beyond the specification's core metadata, the spec also enables
+                developers to quickly share and reuse container setup steps through <a href="./features"
+                    aria-label="See the Dev Container Features spec">Features</a> and <a href="./templates"
+                    aria-label="See the Dev Container Templates spec">Templates</a>. </p>
 
         </div>
         <div class="col-lg-5">
             <div class="row align-items-center">
                 <div class="col-lg-12">
-                    <img alt="Go devcontainer.json config file" src="img/goConfig.png" class="img-fluid rounded"/>
-                    <p class="text-left"><i>Use or create dev container definitions for a multitude of tech stacks and tools.</i></p>
+                    <img alt="Go devcontainer.json config file" src="img/goConfig.png" class="img-fluid rounded" />
+                    <p class="text-left"><i>Use or create dev container definitions for a multitude of tech stacks and
+                            tools.</i></p>
                 </div>
             </div>
-    </div>
+        </div>
 
-    <hr>
+        <hr>
 
-    <div class="row more-info">
-        <div class="col-lg-4">
-            <h1 class="text-center"><img src="img/cogs.png" alt="Gear cogs"></h1>
-            <a href='{{ "/overview" | prepend: site.baseurl }}'><h3 class="text-center">Overview</h3></a>
-            <p>
-                More information about the Development Containers Specification.
-            </p>
-        </div>
-        <div class="col-lg-4">
-            <h1 class="text-center"><img src="img/book.png" alt="Gear cogs"></h1>
-            {% assign sorted = site.implementors | sort: 'index' %}
-            <a href = "{{ sorted.first.url | prepend: site.baseurl }}"><h3 class="text-center">Specification</h3></a>
-            <p>
-                Check out the latest reference implementation and schemas.
-            </p>
-        </div>
-        <div class="col-lg-4">
-            <h1 class="text-center"><img src="img/branch.png" alt="Gear cogs"></h1>
-            <a href = '{{ "/supporting" | prepend: site.baseurl }}'><h3 class="text-center">Supporting Tools</h3></a>
-            <p>
-                A variety of tools and services support this standard.
-            </p>
+        <div class="row more-info">
+            <div class="col-lg-4">
+                <h1 class="text-center"><img src="img/cogs.png" alt="Gear cogs"></h1>
+                <a href='{{ "/overview" | prepend: site.baseurl }}'>
+                    <h3 class="text-center">Overview</h3>
+                </a>
+                <p>
+                    More information about the Development Container Specification.
+                </p>
+            </div>
+            <div class="col-lg-4">
+                <h1 class="text-center"><img src="img/book.png" alt="Gear cogs"></h1>
+                {% assign sorted = site.implementors | sort: 'index' %}
+                <a href="{{ sorted.first.url | prepend: site.baseurl }}">
+                    <h3 class="text-center">Specification</h3>
+                </a>
+                <p>
+                    Check out the latest reference implementation and schemas.
+                </p>
+            </div>
+            <div class="col-lg-4">
+                <h1 class="text-center"><img src="img/branch.png" alt="Gear cogs"></h1>
+                <a href='{{ "/supporting" | prepend: site.baseurl }}'>
+                    <h3 class="text-center">Supporting Tools</h3>
+                </a>
+                <p>
+                    A variety of tools and services support this standard.
+                </p>
+            </div>
         </div>
     </div>
-</div>

--- a/overview.md
+++ b/overview.md
@@ -7,17 +7,17 @@ sectionid: overview
 ## <a href="#overview" name="overview" class="anchor"> What are development containers? </a>
 As containerizing production workloads becomes commonplace, more developers are using containers for scenarios beyond deployment, including continuous integration, test automation, and even full-featured coding environments.
 
-Each scenario’s needs can vary between simple single container environments to complex, orchestrated multi-container setups. Rather than attempting to create another orchestrator format, the Development Containers Specification (or Dev Containers Spec for short) seeks to find ways to enrich existing formats with metadata for common development specific settings, tools, and configuration.
+Each scenario’s needs can vary between simple single container environments to complex, orchestrated multi-container setups. Rather than attempting to create another orchestrator format, the Development Container Specification (or Dev Container Spec for short) seeks to find ways to enrich existing formats with metadata for common development specific settings, tools, and configuration.
 
 ### <a href="#metadata-format" name="metadata-format" class="anchor">  A structured metadata format </a>
 
 Like the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) before it, the first format in the specification, [`devcontainer.json`](implementors/json_reference), was born out of necessity. It is a structured JSON with Comments (jsonc) metadata format that tools can use to store any needed configuration required to develop inside of local or cloud-based containerized coding. 
 
-Since the spec was initally published, Dev Container metadata can now be stored in [image labels](../implementors/spec/#image-metadata) and in reusable chunks of metadata and install scripts known as [Dev Container Features](../features). We envision that this same structured data can be embedded in other formats -- all while retaining a common object model for consistent processing.
+Since the spec was initally published, dev container metadata can now be stored in [image labels](../implementors/spec/#image-metadata) and in reusable chunks of metadata and install scripts known as [Dev Container Features](../features). We envision that this same structured data can be embedded in other formats -- all while retaining a common object model for consistent processing.
 
 ### <a href="#Development-vs-production" name="Development-vs-production" class="anchor"> Development vs production </a>
 
-A Development Container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development.
+A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development.
 
 <img alt="Diagram of inner and outer loop of container-based development" src="img/dev-container-stages.png"/>
 

--- a/supporting.md
+++ b/supporting.md
@@ -4,7 +4,7 @@ layout: singlePage
 sectionid: supporting
 ---
 
-This page outlines tools and services that currently support the development container specification, including the `devcontainer.json` format. A `devcontainer.json` file in your project tells tools and services that support the dev container spec how to access (or create) a dev container with a well-defined tool and runtime stack.
+This page outlines tools and services that currently support the Development Container Specification, including the `devcontainer.json` format. A `devcontainer.json` file in your project tells tools and services that support the dev container spec how to access (or create) a dev container with a well-defined tool and runtime stack.
 
 While most [dev container properties](implementors/json_reference) apply to any `devcontainer.json` supporting tool or service, a few are specific to certain tools, which are outlined below.
 
@@ -35,13 +35,13 @@ Please note that the [Dev Containers](#dev-containers) extension and [GitHub Cod
 
 ### <a href="#visual-studio" name="visual-studio" class="anchor"> Visual Studio </a>
 
-Visual Studio added Dev Container support in Visual Studio 2022 17.4 for C++ projects using CMake Presets. It is part of the Linux and embedded development with C++ workload, so make sure it is selected in your VS installation. Visual Studio manages the lifecycle of Dev Containers it uses as you work, but it treats them as remote targets in a similar way to other Linux or WSL targets.
+Visual Studio added dev container support in Visual Studio 2022 17.4 for C++ projects using CMake Presets. It is part of the Linux and embedded development with C++ workload, so make sure it is selected in your VS installation. Visual Studio manages the lifecycle of dev containers it uses as you work, but it treats them as remote targets in a similar way to other Linux or WSL targets.
 
 You may learn more in the [announcement blog post](https://devblogs.microsoft.com/cppblog/dev-containers-for-c-in-visual-studio/).
 
 ### <a href="#intellij" name="intellij" class="anchor"> IntelliJ IDEA </a>
 
-IntelliJ IDEA has early support Dev Containers that can be run remotely via an SSH connection or locally using Docker.
+IntelliJ IDEA has early support dev containers that can be run remotely via an SSH connection or locally using Docker.
 
 You may learn more in the [announcement blog post](https://blog.jetbrains.com/idea/2023/06/intellij-idea-2023-2-eap-6/#SupportforDevContainers).
 
@@ -49,25 +49,25 @@ You may learn more in the [announcement blog post](https://blog.jetbrains.com/id
 
 ### <a href="#devcontainer-cli" name="devcontainer-cli" class="anchor"> Dev Container CLI </a>
 
-The dev container command line interface (CLI) is a reference implementation for the Dev Container spec. It is in development in the [devcontainers/cli](https://github.com/devcontainers/cli) repo. It is intended both for use directly and by tools or services that want to support the spec.
+The Dev Container Command Line Interface (CLI) is a reference implementation for the Dev Container Spec. It is in development in the [devcontainers/cli](https://github.com/devcontainers/cli) repo. It is intended both for use directly and by tools or services that want to support the spec.
 
-The CLI can take a `devcontainer.json` and create and configure a dev container from it. It allows for prebuilding dev container definitions using a CI or DevOps product like GitHub Actions. It can detect and include dev container features and apply them at container runtime, and run [lifecycle scripts](implementors/json_reference/#lifecycle-scripts) like `postCreateCommand`, providing more power than a plain `docker build` and `docker run`.
+The CLI can take a `devcontainer.json` and create and configure a dev container from it. It allows for prebuilding dev container configurations using a CI or DevOps product like GitHub Actions. It can detect and include dev container features and apply them at container runtime, and run [lifecycle scripts](implementors/json_reference/#lifecycle-scripts) like `postCreateCommand`, providing more power than a plain `docker build` and `docker run`.
 
 #### <a href="#dev-containers-cli" name="dev-containers-cli" class="anchor"> VS Code extension CLI </a>
 
-The [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) includes a variation of the devcontainer CLI that adds the ability use the command line to open a dev container in VS Code. It is also automatically updated when the extension updates. 
+The [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) includes a variation of the Dev Container CLI that adds the ability use the command line to open a dev container in VS Code. It is also automatically updated when the extension updates. 
 
 Press <kbd>cmd/ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> or <kbd>F1</kbd> and select the **Dev Containers: Install devcontainer CLI** command to install it.
 
 ### <a href="#cachix-devenv" name="cachix-devenv" class="anchor"> Cachix devenv </a>
 
-Cachix's **[devenv](https://devenv.sh/)** now supports automatically generating a `.devcontainer.json` file. This gives you a more convenient and consistent way to use [Nix](https://nixos.org/) with any Dev Container spec supporting tool or service!
+Cachix's **[devenv](https://devenv.sh/)** now supports automatically generating a `.devcontainer.json` file. This gives you a more convenient and consistent way to use [Nix](https://nixos.org/) with any Dev Container Spec supporting tool or service!
 
 See [devenv documentation](https://devenv.sh/integrations/codespaces-devcontainer/) for detais. 
 
 ### <a href="#jetpack-io-devbox" name="jetpack-io-devbox" class="anchor"> Jetpack.io Devbox </a>
 
-[Jetpack.io](https://jetpack.io) is a [Nix](https://nixos.org/)-based service for deploying applications. [DevBox](https://www.jetpack.io/devbox/) provides a way to use Nix to generate a development environment. [Jetpack.io's VS Code extension](https://marketplace.visualstudio.com/items?itemName=jetpack-io.devbox) allows you to quickly take advantage of DevBox in any Dev Container spec supporting tool or service. 
+[Jetpack.io](https://jetpack.io) is a [Nix](https://nixos.org/)-based service for deploying applications. [DevBox](https://www.jetpack.io/devbox/) provides a way to use Nix to generate a development environment. [Jetpack.io's VS Code extension](https://marketplace.visualstudio.com/items?itemName=jetpack-io.devbox) allows you to quickly take advantage of DevBox in any Dev Container Spec supporting tool or service. 
 
 Press <kbd>cmd/ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> or <kbd>F1</kbd> and select the **Generate Dev Container files** command to get started!
 
@@ -136,11 +136,11 @@ You can customize which files are initially opened when the codespace is created
 
 The paths are relative to the root of the repository. They will be opened in order, with the first file activated.
 
-Note that currently Codespaces reads these properties from devcontainer.json, not image metadata.
+> **Note** that currently Codespaces reads these properties from `devcontainer.json`, not image metadata.
 
 #### <a href="#codespaces-specific-limitations" name="codespaces-specific-limitations" class="anchor"> Product specific limitations </a>
 
-Some properties may apply differently to Codespaces.
+Some properties may apply differently to codespaces.
 
 | Property or variable | Type | Description |
 |----------|---------|----------------------|
@@ -159,7 +159,6 @@ Some properties may apply differently to Codespaces.
 
 When you import a GitHub repository into CodeSandbox, it will automatically provision a dedicated environment for every branch. Thanks to memory snapshotting, CodeSandbox then resumes and branches an environment in under two seconds.
 
-
 CodeSandbox offers support for multiple editors, so you can code using the CodeSandbox web editor, VS Code, or the CodeSandbox iOS app.
 
 **Tip:** After importing a repository into CodeSandbox, you can use the built-in UI to configure the environment using dev containers.
@@ -171,24 +170,20 @@ All properties specific to CodeSandbox are placed within a `.codesandbox` folder
 
 More details about these can be found in the CodeSandbox [documentation](https://codesandbox.io/docs/learn/repositories/task).
 
-#### Product specific limitations
+#### <a href="#codesandbox-specific-limitations" name="codesandbox-specific-limitations" class="anchor"> Product specific limitations </a>
 
 CodeSandbox runs dev containers using rootless Podman instead of Docker. CodeSandbox also uses [devcontainers/cli](https://github.com/devcontainers/cli) to manage dev containers. So any limitations of rootless Podman and Dev Container CLI should apply to CodeSandbox. 
-
 
 The following properties apply differently to CodeSandbox.
 
 | Property or variable | Type | Description |
 |----------|---------|----------------------|
 | `forwardPorts` | array | CodeSandbox does not need this property. All ports opened in dev containers will be mapped to a public URL automatically. |
-
 | `portsAttributes` | object | CodeSandbox does not yet support this property. Ports are attached to tasks configured in `.codesandbox/tasks.json` and are attributed to the tasks.|
 | `otherPortsAttributes` | object | CodeSandbox does not yet support this property. |
 | `remoteUser` | string | CodeSandbox currently ignores this property and overrides this as `root`. CodeSandbox uses rootless Podman to run containers. Running with a non-root remote user is the same as running as a root remote user in rootless Podman, from a security perspective. CodeSandbox plans on supporting this in the future. |
 | `shutdownAction` | string | Does not apply to CodeSandbox. |
-
 | `capAdd` | array | CodeSandbox does not support adding docker capabilities. As the containers are run as a non-root user, capabilities that need root access will not work. |
-
 | `features` | object | CodeSandbox automatically adds docker-cli to the container and connects to the host socket. Features like `docker-in-docker` and `docker-outside-of-docker` will work a bit differently. As the docker-cli and socket from host are accessible in the container, most use cases should work as expected. |
 | `${localEnv:VARIABLE_NAME}` | Any | For CodeSandbox, the host is in the cloud rather than in your local machine.|
 | `hostRequirements` | object | CodeSandbox does not yet support this property. |
@@ -196,7 +191,7 @@ The following properties apply differently to CodeSandbox.
 
 ### <a href="#devpod" name="devpod" class="anchor"> DevPod </a>
 
-[DevPod](https://github.com/loft-sh/devpod) is a client-only tool to create reproducible developer environments based on a devcontainer.json on any backend. Each developer environment runs in a container and is specified through a devcontainer.json. Through DevPod providers these environments can be created on any backend, such as the local computer, a Kubernetes cluster, any reachable remote machine or in a VM in the cloud.
+[DevPod](https://github.com/loft-sh/devpod) is a client-only tool to create reproducible developer environments based on a `devcontainer.json` on any backend. Each developer environment runs in a container and is specified through a `devcontainer.json`. Through DevPod providers these environments can be created on any backend, such as the local computer, a Kubernetes cluster, any reachable remote machine or in a VM in the cloud.
 
 ### <a href="#schema" name="schema" class="anchor"> Schema </a>
 


### PR DESCRIPTION
Complete the edit pass mentioned in https://github.com/devcontainers/spec/issues/293#issuecomment-1741545357

Main changes:
- Refer to the spec as "Development Container Specification"
     - All caps
     - Singular "Container" rather than "Containers" (plural feels awkward)
- The term "dev container" shouldn't be capitalized on its own
- Signify `devcontainer.json` is a file type through `
- Features
     - Entire name is "Dev Container Features" (note the caps)
     - On their own, "Features" (note the caps)
- Templates - same as Features 
- Refer to CLI as "Dev Container CLI" (note the caps)
- Just use bolding for emphasis sprinkled throughout sections, rather than try to use it to always bold certain terms (this felt inconsistent and confusing)
- Various other typos or formatting issues (i.e. the new CodeSandbox supporting tools section had some table issues)

I'll similarly review https://github.com/devcontainers/spec to provide a similar edit pass, following the guidance established here.