### PR TITLE
update docs to have working oras examples

### DIFF
--- a/_implementors/features-distribution.md
+++ b/_implementors/features-distribution.md
@@ -116,7 +116,7 @@ ARTIFACT_PATH=devcontainer-feature-go.tgz
 for VERSION in 1  1.2  1.2.3  latest
 do
     oras push ${REGISTRY}/${NAMESPACE}/${FEATURE}:${VERSION} \
-            --manifest-config /dev/null:application/vnd.devcontainers \
+            --config /dev/null:application/vnd.devcontainers \
                              ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
 done
 ```
@@ -131,7 +131,7 @@ REGISTRY=ghcr.io
 NAMESPACE=devcontainers/features
 
 oras push ${REGISTRY}/${NAMESPACE}:latest \
-        --manifest-config /dev/null:application/vnd.devcontainers \
+        --config /dev/null:application/vnd.devcontainers \
                             ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
 ```
 

--- a/_implementors/templates-distribution.md
+++ b/_implementors/templates-distribution.md
@@ -113,7 +113,7 @@ ARTIFACT_PATH=devcontainer-template-go.tgz
 for VERSION in 1  1.2  1.2.3  latest
 do
         oras push ${REGISTRY}/${NAMESPACE}/${TEMPLATE}:${VERSION} \
-                --manifest-config /dev/null:application/vnd.devcontainers \
+                --config /dev/null:application/vnd.devcontainers \
                         ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
 done
 
@@ -129,7 +129,7 @@ REGISTRY=ghcr.io
 NAMESPACE=devcontainers/templates
 
 oras push ${REGISTRY}/${NAMESPACE}:latest \
-        --manifest-config /dev/null:application/vnd.devcontainers \
+        --config /dev/null:application/vnd.devcontainers \
                             ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
 ```
 


### PR DESCRIPTION
The push and pull examples do not work with the current cli.  The latest oras documentation describes the use of the `--config` option for the [push](https://oras.land/docs/commands/oras_push) and [pull](https://oras.land/docs/commands/oras_pull) commands.  This parameter change (rename the `--manifest-config` to `--config`) was [documented as a breaking change](https://github.com/oras-project/oras/releases/tag/v0.14.0) in version 0.14.0 of the ORAS CLI, which was released in August 2022.