### PR TITLE
Add Logic App Standard Template

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -623,3 +623,8 @@
   contact: https://github.com/brokenpip3/devcontainers-bats/issues
   repository: https://github.com/brokenpip3/devcontainers-bats
   ociReference: ghcr.io/brokenpip3/devcontainers-bats
+- name: Logic App Standard Template
+  maintainer: mcollier
+  contact: https://github.com/mcollier/logic-app-dev-container-template/issues
+  repository: https://github.com/mcollier/logic-app-dev-container-template
+  ociReference: ghcr.io/mcollier/logic-app-dev-container-template/logic-app-standard

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -627,4 +627,4 @@
   maintainer: mcollier
   contact: https://github.com/mcollier/logic-app-dev-container-template/issues
   repository: https://github.com/mcollier/logic-app-dev-container-template
-  ociReference: ghcr.io/mcollier/logic-app-dev-container-template/logic-app-standard
+  ociReference: ghcr.io/mcollier/logic-app-dev-container-template


### PR DESCRIPTION
This pull request adds a new collection called "Logic App Standard Template" to the `_data/collection-index.yml` file.

Main change:

* `_data/collection-index.yml`: Added a new collection called "Logic App Standard Template". (Code changes in `_data/collection-index.yml`)