### PR TITLE
Add Mohd Shukri Hasan's devcontainer templates

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -638,3 +638,8 @@
   contact: https://github.com/lumenpink/devcontainer-features/issues
   repository: https://github.com/lumenpink/devcontainer-features
   ociReference: ghcr.io/lumenpink/devcontainer-features
+- name: Templates by Mohd Shukri Hasan
+  maintainer: Mohd Shukri Hasan
+  contact: https://github.com/hsm207/devcontainer-templates/issues
+  ociReference: ghcr.io/hsm207/devcontainer-templates
+

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -641,5 +641,6 @@
 - name: Templates by Mohd Shukri Hasan
   maintainer: Mohd Shukri Hasan
   contact: https://github.com/hsm207/devcontainer-templates/issues
+  repository: https://github.com/hsm207/devcontainer-templates
   ociReference: ghcr.io/hsm207/devcontainer-templates
 


### PR DESCRIPTION
Update with my devcontainer templates repository: https://github.com/hsm207/devcontainer-templates

Adding templates for learning new technologies e.g. qiskit and contributing to OSS projects that have complicated setup steps but no devcontainer support.