### PR TITLE
Add a collection to the index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -687,4 +687,9 @@
   maintainer: Mikael Koskinen
   contact: https://github.com/weikio/devcontainer-templates/issues
   repository: https://github.com/weikio/devcontainer-templates
-  ociReference: ghcr.io/weikio/devcontainer-templates  
+  ociReference: ghcr.io/weikio/devcontainer-templates
+- name: Dev Container Features by Hans Spaans
+  maintainer: Hans Spaans
+  contact: https://github.com/hspaans/devcontainer-features/issues
+  repository: https://github.com/hspaans/devcontainer-features
+  ociReference: ghcr.io/hspaans/devcontainer-features


### PR DESCRIPTION
Adding [reference](https://github.com/hspaans/devcontainer-features) to a collection of devcontainer features to mainly work with Python and Ansible projects:

- ansible-lint: Ansible Lint
- pyadr: Python ADR
- pytest: Pytest
- pyupgrade: Pyupgrade
- sshpass: SSH Pass for Ansible