### PR TITLE
Add joshuanianji/devcontainer-templates

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -718,3 +718,8 @@
   contact: https://github.com/veronoicc/devcontainer-features/issues
   repository: https://github.com/veronoicc/devcontainer-features
   ociReference: ghcr.io/veronoicc/devcontainer-features
+- name: Dev Container Templates by joshuanianji
+  maintainer: joshuanianji
+  contact: https://github.com/joshuanianji/devcontainer-templates/issues
+  repository: https://github.com/joshuanianji/devcontainer-templates
+  ociReference: ghcr.io/joshuanianji/devcontainer-templates


### PR DESCRIPTION
Add templates from [joshuanianji/devcontainer-templates](https://github.com/joshuanianji/devcontainer-templates).

There are two so far: [idris2](https://github.com/joshuanianji/devcontainer-templates/blob/main/src/idris2) and [javascript-node-edgedb](https://github.com/joshuanianji/devcontainer-templates/blob/main/src/javascript-node-edgedb)