### PR TITLE
Add va-h/devcontainers-features

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -728,3 +728,8 @@
   contact: https://github.com/orgs/opencodeco/discussions
   repository: https://github.com/opencodeco/devcontainers
   ociReference: ghcr.io/opencodeco/devcontainers
+- name: Dev Container Features by Valentin
+  maintainer: Valentin Heiligers
+  contact: https://github.com/va-h/devcontainers-features/issues
+  repository: https://github.com/va-h/devcontainers-features
+  ociReference: ghcr.io/va-h/devcontainers-features


### PR DESCRIPTION
Hello,

I dearly missed [astral-sh/uv](https://github.com/astral-sh/uv) and [Wilfred/difftastic](https://github.com/Wilfred/difftastic) as features.

* [va-h/devcontainers-feature/difftastic](https://github.com/va-h/devcontainers-features/tree/main/src/difftastic)
* [va-h/devcontainers-feature/uv](https://github.com/va-h/devcontainers-features/tree/main/src/uv)