### PR TITLE
Update docs and guidance for contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
+-->
+
+## What type of PR is this?
+
+- [ ] Add a new dev container collection
+- [ ] Update to an existing dev container collection
+- [ ] Documentation/spec update
+- [ ] Other containers.dev site update (UX, layout, etc)
+
+## Related Issues
+
+<!--
+For pull requests that relate or close an issue, please include them
+below. For example: "closes #1234" would connect the current pull
+request to issue 1234. When we merge the pull request, Github will
+automatically close the issue.
+-->
+
+- Related Issue #
+- Closes #
+
+## Description
+
+_Please replace this line with a description of your PR._
+
+### Collection checklist
+_If your PR contributes a new collection, please utilize this checklist:_
+- [ ] Collection name
+- [ ] Maintainer name
+- [ ] Maintainer contact link (i.e. link to a GitHub repo, email)
+- [ ] Repository URL
+- [ ] OCI Reference
+- [ ] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.

--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -1,8 +1,14 @@
-# How to Contribute to the Dev Container Specification
+---
+layout: implementors
+title:  "How to contribute to the Development Container Specification"
+shortTitle: "Contributing"
+author: Microsoft
+index: 9
+---
 
-We're excited for your contributions to the dev container specification! This document outlines how you can get involved. 
+We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
 
-## Spec contribution approaches
+## <a href="#contribution-approaches" name="contribution-approaches" class="anchor"> Spec Contribution approaches </a>
 
 If you'd like to contribute a change or addition to the spec, you may follow the guidance below:
 - Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in this repository. Try to get early feedback before spending too much effort formalizing it.
@@ -16,9 +22,9 @@ Here is a sample:
 
 - PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
 
-Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
+Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://aka.ms/devcontainer.json). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 
-### Contributing tool-specific support
+### <a href="#tool-specific-support" name="tool-specific-support" class="anchor"> Contributing tool-specific support </a>
 
 Tool-specific properties are contained in namespaces in the `"customizations"` property. For instance, VS Code specific properties are formated as:
 
@@ -37,7 +43,7 @@ Tool-specific properties are contained in namespaces in the `"customizations"` p
 
 You may propose adding a new namespace for a specific tool, and any properties specific to that tool.
 
-## Formatting Guidelines
+### <a href="#formatting-guidelines" name="formatting-guidelines" class="anchor"> Formatting Guidelines </a>
 
 When contributing an official doc or referencing dev containers in your projects, please consider the following guidelines:
 
@@ -51,7 +57,7 @@ When contributing an official doc or referencing dev containers in your projects
 - Refer to the CLI as the "Dev Container CLI" (note the caps)
 - Use bolding for emphasis sprinkled throughout sections, rather than try to use it to always bold certain terms
 
-## Review process
+## <a href="#review-process" name="review-process" class="anchor"> Review process </a>
 
 We use the following [labels](https://github.com/devcontainers/spec/labels):
 
@@ -60,7 +66,8 @@ We use the following [labels](https://github.com/devcontainers/spec/labels):
 
 [Milestones](https://github.com/devcontainers/spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.
 
-## Community Engagement
+## <a href="#community-engagement" name="community-engagement" class="anchor"> Community Engagement </a>
+
 There are several additional options to engage with the dev container community, such as asking questions, providing feedback, or engaging on how your team may use or contribute to dev containers:
 - [GitHub Discussions](https://github.com/devcontainers/spec/discussions): This is a great opportunity to connect with the community and maintainers of this project, without the requirement of contributing a change to the actual spec (which we see more in issues and PRs)
 - [Community Slack channel](https://aka.ms/dev-container-community): This is a great opportunity to connect with the community and maintainers

--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -1,30 +1,24 @@
----
-layout: implementors
-title:  "How to contribute to the Development Container Specification"
-shortTitle: "Contributing"
-author: Microsoft
-index: 9
----
+# How to Contribute to the Dev Container Specification
 
-We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. We also welcome you to join our [community Slack channel](https://aka.ms/dev-container-community).
+We're excited for your contributions to the dev container specification! This document outlines how you can get involved. 
 
-## <a href="#contribution-approaches" name="contribution-approaches" class="anchor"> Contribution approaches </a>
+## Spec contribution approaches
 
-- Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in the [spec repo](https://github.com/devcontainers/spec). Try to get early feedback before spending too much effort formalizing it.
-- More formally document the proposed change in terms of properties and their semantics. Look to format your proposal like our [devcontainer.json reference](../json_reference), which is a JSON with Comments (jsonc) format.
+If you'd like to contribute a change or addition to the spec, you may follow the guidance below:
+- Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in this repository. Try to get early feedback before spending too much effort formalizing it.
+- More formally document the proposed change in terms of properties and their semantics. Look to format your proposal like our [devcontainer.json reference](https://aka.ms/devcontainer.json).
 
-Here is a sample proposal:
+Here is a sample:
 
-| Property | Type  | Description |
-|:------------------|:------------|:------------|
-| `image`    | string      | **Required** when using an image. The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
-{: .table .table-bordered .table-responsive}
+| Property | Type | Description |
+|----------|------|-------------|
+| `image` | string | **Required** when [using an image](/docs/remote/create-dev-container.md#using-an-image-or-dockerfile). The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
 
 - PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
 
-Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://aka.ms/devcontainer.json). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
+Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 
-### <a href="#tool-specific-support" name="tool-specific-support" class="anchor"> Contributing tool-specific support </a>
+### Contributing tool-specific support
 
 Tool-specific properties are contained in namespaces in the `"customizations"` property. For instance, VS Code specific properties are formated as:
 
@@ -43,11 +37,32 @@ Tool-specific properties are contained in namespaces in the `"customizations"` p
 
 You may propose adding a new namespace for a specific tool, and any properties specific to that tool.
 
-## <a href="#review-process" name="review-process" class="anchor"> Review process </a>
+## Formatting Guidelines
 
-We use the following [labels](https://github.com/devcontainers/spec/labels) in the spec repo:
+When contributing an official doc or referencing dev containers in your projects, please consider the following guidelines:
+
+- Refer to the spec as the "Development Container Specification"
+     - All capital letters
+     - Singular "Container" rather than plural "Containers"
+- The term "dev container" shouldn't be capitalized on its own
+     - It should only be capitalized when referring to an official tool title, like the VS Code Dev Containers extension 
+- Signify `devcontainer.json` is a file type through backticks 
+- Features and Templates should always be capitalized
+- Refer to the CLI as the "Dev Container CLI" (note the caps)
+- Use bolding for emphasis sprinkled throughout sections, rather than try to use it to always bold certain terms
+
+## Review process
+
+We use the following [labels](https://github.com/devcontainers/spec/labels):
 
 - `proposal`: Issues under discussion, still collecting feedback.
 - `finalization`: Proposals we intend to make part of the spec.
 
 [Milestones](https://github.com/devcontainers/spec/milestones) use a "month year" pattern (i.e. January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.
+
+## Community Engagement
+There are several additional options to engage with the dev container community, such as asking questions, providing feedback, or engaging on how your team may use or contribute to dev containers:
+- [GitHub Discussions](https://github.com/devcontainers/spec/discussions): This is a great opportunity to connect with the community and maintainers of this project, without the requirement of contributing a change to the actual spec (which we see more in issues and PRs)
+- [Community Slack channel](https://aka.ms/dev-container-community): This is a great opportunity to connect with the community and maintainers
+- You can always check out the issues and PRs (and contribute new ones) across the repos in the [Dev Containers GitHub org](https://github.com/devcontainers) too!
+- Community collections: You can contribute your own [Templates](https://containers.dev/implementors/templates-distribution/#distribution) and [Features](https://containers.dev/implementors/features-distribution/#distribution) to our [community index](https://containers.dev/collections)!

--- a/_implementors/contributing.md
+++ b/_implementors/contributing.md
@@ -6,7 +6,7 @@ author: Microsoft
 index: 9
 ---
 
-We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
+We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. We also welcome you to join our [community Slack channel](https://aka.ms/dev-container-community).
 
 ## <a href="#contribution-approaches" name="contribution-approaches" class="anchor"> Spec Contribution approaches </a>
 
@@ -16,9 +16,10 @@ If you'd like to contribute a change or addition to the spec, you may follow the
 
 Here is a sample:
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `image` | string | **Required** when [using an image](/docs/remote/create-dev-container.md#using-an-image-or-dockerfile). The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
+| Property | Type  | Description |
+|:------------------|:------------|:------------|
+| `image`    | string      | **Required** when using an image. The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
+{: .table .table-bordered .table-responsive}
 
 - PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
 
@@ -59,7 +60,7 @@ When contributing an official doc or referencing dev containers in your projects
 
 ## <a href="#review-process" name="review-process" class="anchor"> Review process </a>
 
-We use the following [labels](https://github.com/devcontainers/spec/labels):
+We use the following [labels](https://github.com/devcontainers/spec/labels) in the spec repo:
 
 - `proposal`: Issues under discussion, still collecting feedback.
 - `finalization`: Proposals we intend to make part of the spec.

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # How to Contribute to the Dev Container Specification
 
-We're excited for your contributions to the dev container specification! This document outlines how you can get involved. 
+We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
 
 ## Spec contribution approaches
 
@@ -16,7 +16,7 @@ Here is a sample:
 
 - PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
 
-Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
+Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://aka.ms/devcontainer.json). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 
 ### Contributing tool-specific support
 

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 
 We're excited for your contributions to the dev container specification! This document outlines how you can get involved. 
 
-## Contribution approaches
+## Spec contribution approaches
 
 If you'd like to contribute a change or addition to the spec, you may follow the guidance below:
 - Propose the change via an [issue](https://github.com/devcontainers/spec/issues) in this repository. Try to get early feedback before spending too much effort formalizing it.
@@ -65,4 +65,4 @@ There are several additional options to engage with the dev container community,
 - [GitHub Discussions](https://github.com/devcontainers/spec/discussions): This is a great opportunity to connect with the community and maintainers of this project, without the requirement of contributing a change to the actual spec (which we see more in issues and PRs)
 - [Community Slack channel](https://aka.ms/dev-container-community): This is a great opportunity to connect with the community and maintainers
 - You can always check out the issues and PRs (and contribute new ones) across the repos in the [Dev Containers GitHub org](https://github.com/devcontainers) too!
-
+- Community collections: You can contribute your own [Templates](https://containers.dev/implementors/templates-distribution/#distribution) and [Features](https://containers.dev/implementors/features-distribution/#distribution) to our [community index](https://containers.dev/collections)!

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # How to Contribute to the Dev Container Specification
 
-We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. 
+We're excited for your contributions to the Dev Container Specification! This document outlines how you can get involved. We also welcome you to join our [community Slack channel](https://aka.ms/dev-container-community).
 
 ## Spec contribution approaches
 
@@ -53,7 +53,7 @@ When contributing an official doc or referencing dev containers in your projects
 
 ## Review process
 
-We use the following [labels](https://github.com/devcontainers/spec/labels):
+We use the following [labels](https://github.com/devcontainers/spec/labels) in the spec repo:
 
 - `proposal`: Issues under discussion, still collecting feedback.
 - `finalization`: Proposals we intend to make part of the spec.

--- a/features.html
+++ b/features.html
@@ -18,6 +18,12 @@ sectionid: collection-index-features
     Please note that if you need to report a Feature, you should do so through the registry hosting the Feature.
 </p>
 
+<p>
+    To add your own collection to this list, please create a PR editing <a
+        href="https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml">this
+        yaml file</a>.
+</p>
+
 <input type="text" id="searchInput" placeholder="Search">
 <br>
 <br>

--- a/templates.html
+++ b/templates.html
@@ -16,6 +16,12 @@ sectionid: collection-index-templates
     Please note that if you need to report a Template, you should do so through the registry hosting the Template.
 </p>
 
+<p>
+    To add your own collection to this list, please create a PR editing <a
+        href="https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml">this
+        yaml file</a>.
+</p>
+
 <input type="text" id="searchInput" placeholder="Search">
 <br>
 <br>


### PR DESCRIPTION
Update resources and documentation to help with community contributions:
- Add a new PR template (based on the great work from [forem](https://github.com/forem/forem/edit/main/.github/PULL_REQUEST_TEMPLATE.md))
- Add links to collection-index.yml from the Features and Templates pages (we already link to it from the Collections page)
- Update the Contribution Guides that appear on containers.dev and are part of this backing repo
     - Add info on contributing Templates and Features
     - Make them consistent with each other (in content and formatting; i.e. the one displayed on containers.dev was missing the latest formatting info we added to the other guide)

This is a simpler version way to achieve the goals from https://github.com/devcontainers/devcontainers.github.io/pull/354.