### PR TITLE
adding k3s-on-host feature

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -678,10 +678,10 @@
   contact: https://github.com/rsm-hcd
   repository: https://github.com/rsm-hcd/devcontainer-templates
   ociReference: ghcr.io/rsm-hcd/devcontainer-templates
-- name: Additional Dev Container Features by Georg Ofenbeck 
+- name: Additional Dev Container Features by Georg Ofenbeck
   maintainer: Georg Ofenbeck
   contact: https://github.com/GeorgOfenbeck/features/issues
-  repository: https://github.com/GeorgOfenbeck/features 
+  repository: https://github.com/GeorgOfenbeck/features
   ociReference: ghcr.io/georgofenbeck/features
 - name: Dev Container Features by Niko Böckerman
   maintainer: Niko Böckerman
@@ -707,7 +707,7 @@
   maintainer: johnluicn
   contact: https://github.com/johnluicn/devcontainer-templates/issues
   repository: https://github.com/johnluicn/devcontainer-templates
-  ociReference: ghcr.io/johnluicn/devcontainer-templates  
+  ociReference: ghcr.io/johnluicn/devcontainer-templates
 - name: Bob buildsystem and DevBox features
   maintainer: Dirk Louwers
   contact: https://github.com/dlouwers/devcontainer-features/issues
@@ -767,7 +767,7 @@
   maintainer: Cadu Ribeiro
   contact: https://github.com/duduribeiro/devcontainer-features/issues
   repository: https://github.com/duduribeiro/devcontainer-features/
-  ociReference: ghcr.io/duduribeiro/devcontainer-features  
+  ociReference: ghcr.io/duduribeiro/devcontainer-features
 - name: Dev Container Features by skriptfabrik
   maintainer: skriptfabrik
   contact: https://github.com/skriptfabrik/devcontainer-features/issues
@@ -822,4 +822,9 @@
   maintainer: Carsten Behring
   contact: https://github.com/scicloj/devcontainer-templates/issues
   repository: https://github.com/scicloj/devcontainer-templates/
-  ociReference: ghcr.io/scicloj/devcontainer-templates  
+  ociReference: ghcr.io/scicloj/devcontainer-templates
+- name: k3s On Host
+  maintainer: k3s on Host Maintainers
+  contact: https://github.com/microsoft/devcontainer-feature-k3s/issues
+  repository: https://github.com/microsoft/devcontainer-feature-k3s
+  ociReference: ghcr.io/microsoft/devcontainers/features/k3s-on-host


### PR DESCRIPTION
## What type of PR is this?

- [X] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Adds the k3s-on-host devcontainer feature that will install k3s on the host machine and enable kubectl / helm interaction from within the devcontainer

### Collection checklist
- [X] Collection name
- [X] Maintainer name
- [X] Maintainer contact link (i.e. link to a GitHub repo, email)
- [X] Repository URL
- [X] OCI Reference
- [X] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.