### PR TITLE
add ghcr.io/sidecus/devcontainer-features

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -868,3 +868,8 @@
   contact: https://github.com/sleter/mojo-devcontainer/issues
   repository: https://github.com/sleter/mojo-devcontainer
   ociReference: ghcr.io/sleter/mojo-devcontainer
+- name: Devcontainer features by sidecus
+  maintainer: sidecus
+  contact: https://github.com/sidecus/devcontainer-features/issues
+  repository: https://github.com/sidecus/devcontainer-features
+  ociReference: ghcr.io/sidecus/devcontainer-features


### PR DESCRIPTION
add ghcr.io/sidecus/devcontainer-features to index

<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

## Description

Add ghcr.io/sidecus/devcontainer-features to public index. It now provides an automatic mirror setup feature for devcontainers.

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Devcontainer features by sidecus
- [x] sidecus
- [x] [Maintainer contact link (i.e. link to a GitHub repo, email)](https://github.com/sidecus/devcontainer-features/issues)
- [x] [Repository URL](https://github.com/sidecus/devcontainer-features)
- [x] ghcr.io/sidecus/devcontainer-features
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.