### PR TITLE
fix: update link to devcontainer-collection.json

### DIFF
--- a/_implementors/features-distribution.md
+++ b/_implementors/features-distribution.md
@@ -23,7 +23,7 @@ Goals include:
 
 Features source code is stored in a git repository.
 
-For ease of authorship and maintenance, [1..n] features can share a single git repository. This set of Features is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
+For ease of authorship and maintenance, [1..n] features can share a single git repository. This set of Features is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection-json) file and "namespace" (eg. `<owner>/<repo>`).
 
 Source code for the set follows the example file structure below:
 


### PR DESCRIPTION
<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [ ] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [x] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below. For example: "closes #1234" would connect the current pull
request to issue 1234. When we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Description

I noticed that link to devcontainer-collection.json section on [Features distribution - Source Code](https://containers.dev/implementors/features-distribution/#source-code) is not working
Changing the `.` to `-` in the link address fixes that

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [ ] Collection name
- [ ] Maintainer name
- [ ] Maintainer contact link (i.e. link to a GitHub repo, email)
- [ ] Repository URL
- [ ] OCI Reference
- [ ] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.