### PR TITLE
collection-index.yml: add feature 'perl'

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -923,7 +923,7 @@
   contact: https://github.com/lx-0/devcontainer-templates/issues
   repository: https://github.com/lx-0/devcontainer-templates
   ociReference: ghcr.io/lx-0/devcontainer-templates
-- name: "Hauke's Features for Development Containers"
+- name: Hauke's Features for Development Containers
   maintainer: Hauke D
   contact: https://github.com/haukex/devcontainer-features/issues
   repository: https://github.com/haukex/devcontainer-features

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -923,3 +923,8 @@
   contact: https://github.com/lx-0/devcontainer-templates/issues
   repository: https://github.com/lx-0/devcontainer-templates
   ociReference: ghcr.io/lx-0/devcontainer-templates
+- name: "Hauke's Features for Development Containers"
+  maintainer: Hauke D
+  contact: https://github.com/haukex/devcontainer-features/issues
+  repository: https://github.com/haukex/devcontainer-features
+  ociReference: ghcr.io/haukex/devcontainer-features


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

- none

## Description

I would appreciate my feature collection to be added to the list. Currently, it only provides one feature, Perl development support, which as far as I can tell no other feature provides. I may add more features in the future.

### Collection checklist

- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.