### PR TITLE
Add devcontainer features by kadykov

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -962,3 +962,8 @@
   contact: https://github.com/davzucky/devcontainers-features-wolfi/issues
   repository: https://github.com/davzucky/devcontainers-features-wolfi
   ociReference: ghcr.io/davzucky/devcontainers-features-wolfi  
+- name: devcontainer features by kadykov
+  maintainer: Aleksandr Kadykov
+  contact: https://github.com/kadykov/devcontainer-features/issues
+  repository: https://github.com/kadykov/devcontainer-features
+  ociReference: ghcr.io/kadykov/devcontainer-features 


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

I'd like to contribute my collection of devcontainer features.
Currently,
it only includes a `pre-commit` feature
that installs this package as a system package.
This is intended for users
who don't have specific version requirements for Python and `pre-commit`.

The main advantage of this feature is that it works on a broad range of images.

- Ubuntu >= 22.04
- Debian >= 11
- Alpine >= 3.20
- Fedora >= 31
- AlmaLinux, Rockylinux, CentOS Stream >= 9

### Collection checklist

- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.