### PR TITLE
Adobe Commerce and Magento devcontainer template repo

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -962,3 +962,8 @@
   contact: https://github.com/davzucky/devcontainers-features-wolfi/issues
   repository: https://github.com/davzucky/devcontainers-features-wolfi
   ociReference: ghcr.io/davzucky/devcontainers-features-wolfi  
+- name: devcontainer templates by Doug Hatcher for Adobe Commerce
+  maintainer: Doug Hatcher
+  contact: https://github.com/doughatcher/devcontainer-templates/issues
+  repository: https://github.com/doughatcher/devcontainer-templates
+  ociReference: ghcr.io/doughatcher/devcontainer-templates


### PR DESCRIPTION
Adds Doug Hatcher's devcontainer templates repo that adds support for Adobe Commerce and friends

## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Adds a devcontainer template repo that includes my devcontainer configurations for running Adobe Commerce and Magento. Will add AEM and Edge Delivery Service support in the future!

### Collection checklist
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.