### PR TITLE
Updating collection-index.yml with j2udev features and templates

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -962,3 +962,13 @@
   contact: https://github.com/davzucky/devcontainers-features-wolfi/issues
   repository: https://github.com/davzucky/devcontainers-features-wolfi
   ociReference: ghcr.io/davzucky/devcontainers-features-wolfi  
+- name: Dev Container Features by j2udev
+  maintainer: j2udev
+  contact: https://github.com/j2udev/devcontainer-features/issues
+  repository: https://github.com/j2udev/devcontainer-features
+  ociReference: ghcr.io/j2udev/devcontainer-features
+- name: Dev Container Templates by j2udev
+  maintainer: j2udev
+  contact: https://github.com/j2udev/devcontainer-templates/issues
+  repository: https://github.com/j2udev/devcontainer-templates
+  ociReference: ghcr.io/j2udev/devcontainer-templates


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Would like to get my features and collections to show up in vscode and [here](https://containers.dev/features).  Reading the docs and looking at past PRs, it looks like this is all you need to do?

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.