### PR TITLE
Add DevContainer feature to install apt dependencies defined in an `Aptfile.dev` file

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -962,3 +962,8 @@
   contact: https://github.com/davzucky/devcontainers-features-wolfi/issues
   repository: https://github.com/davzucky/devcontainers-features-wolfi
   ociReference: ghcr.io/davzucky/devcontainers-features-wolfi  
+- name: devcontainer feature to install apt dependencies defined in an `Aptfile.dev` file.
+  maintainer: Viktor Schmidt
+  contact: https://github.com/viktorianer/devcontainer-features/issues
+  repository: https://github.com/viktorianer/devcontainer-features/tree/main/src/apt
+  ociReference: ghcr.io/viktorianer/devcontainer-features/apt


### PR DESCRIPTION
Install apt dependencies defined in an `Aptfile.dev` file. This feature is inspired by the approach found in [heroku-buildpack-apt](https://github.com/heroku/heroku-buildpack-apt) and [Aptfile Buildpack on App Platform](https://docs.digitalocean.com/products/app-platform/reference/buildpacks/aptfile/). It simplifies the process of managing and installing apt packages required for a development environment by specifying them in one file.

### Additional Information:

Based on the approach found in https://github.com/heroku/heroku-buildpack-apt and https://docs.digitalocean.com/products/app-platform/reference/buildpacks/aptfile/.


## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

- Related Issue https://github.com/devcontainers/features/pull/1136

## Description

#### Usage:

To use the feature, include the following in your `devcontainer.json`:

```json
{
  "features": {
    "ghcr.io/devcontainers/features/apt:1": {
      "devFile": "../Aptfile.dev"
    }
  }
}
```

Example `Aptfile.dev`

```bash
# Video thumbnails
ffmpeg
libvips

# PDF thumbnails
poppler-utils

# PostgreSQL
libpq-dev
postgresql-client
```

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.