### PR TITLE
update collection-index.yml - remove collection for Airplane.dev CLI

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -338,11 +338,6 @@
   contact: https://github.com/ksh5022/devcontainer-features/issues
   repository: https://github.com/ksh5022/devcontainer-features
   ociReference: ghcr.io/ksh5022/devcontainer-features
-- name: GMkonan devcontainer features
-  maintainer: GMkonan
-  contact: https://github.com/GMkonan/feature/issues
-  repository: https://github.com/GMkonan/feature
-  ociReference: ghcr.io/gmkonan/feature
 - name: Dapr devcontainer features
   maintainer: Dapr maintainers
   contact: https://github.com/dapr/cli/issues


### PR DESCRIPTION
## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

## Description

The collection "GMkonan devcontainer features" is only for one feature ("Airplane.dev CLI (airplane)"). As stated in the repository connected to the feature, the service "airplane.dev" and the CLI are discontinued and the feature is now not useable anymore.
The collection can be safely removed.

See: https://github.com/GMkonan/feature/blob/main/README.md