### PR TITLE
Add HTTPie Feature

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1077,3 +1077,8 @@
   contact: https://github.com/mrsimonemms/devcontainers/issues
   repository: https://github.com/mrsimonemms/devcontainers
   ociReference: ghcr.io/mrsimonemms/devcontainers
+- name: HTTPie Feature
+  maintainer: Ferdinand Keller
+  contact: https://github.com/ferdinandkeller/features/issues
+  repository: https://github.com/ferdinandkeller/features
+  ociReference: ghcr.io/ferdinandkeller/features/httpie


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Adds an [HTTPie](https://httpie.io/) feature to install `httpie`, `http` and `https` commands.

### Collection checklist
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.