### PR TITLE
Fix `ociReference` for Rojo and Roblox collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1072,13 +1072,13 @@
   contact: https://github.com/ferdinandkeller/features/issues
   repository: https://github.com/ferdinandkeller/features
   ociReference: ghcr.io/ferdinandkeller/features/httpie
-- name: Rojo
+- name: Rojo Feature
   maintainer: Ryan Luu
   contact: https://github.com/RyanLua/features/issues
   repository: https://github.com/RyanLua/features
-  ociReference: ghcr.io/ryanlua/features/rojo
-- name: Roblox
+  ociReference: ghcr.io/ryanlua/features
+- name: Roblox Template
   maintainer: Ryan Luu
   contact: https://github.com/RyanLua/templates/issues
   repository: https://github.com/RyanLua/templates
-  ociReference: ghcr.io/ryanlua/templates/roblox
+  ociReference: ghcr.io/ryanlua/templates


### PR DESCRIPTION
Fixes the ociReference for Rojo and Roblox collection

<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below. For example: "closes #1234" would connect the current pull
request to issue 1234. When we merge the pull request, Github will
automatically close the issue.
-->

## Description

Fixes the `ociReference` field for my collections which I added in #582 so that my features and templates now show on the website. 