### PR TITLE
add Couper devcontainer feature to the index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1176,7 +1176,7 @@
   maintainer: Pedro Rodrigues
   contact: https://github.com/pirpedro/features/issues
   repository: https://github.com/pirpedro/features
-  ociReference: ghcr.io/pirpedro/features  
+  ociReference: ghcr.io/pirpedro/features
 - name: Dev container features for Azure linux images
   maintainer: Victor Maznev
   contact: https://github.com/bullmastiffo/devcontainers-features/issues
@@ -1257,3 +1257,8 @@
   contact: https://github.com/pairspaces/devcontainers/issues
   repository: https://github.com/pairspaces/devcontainers
   ociReference: ghcr.io/pairspaces/devcontainers/pairspaces
+- name: Couper DevContainer Feature
+  maintainer: Marcel Ludwig (malud)
+  contact: https://github.com/coupergateway/features/issues
+  repository: https://github.com/coupergateway/features
+  ociReference: ghcr.io/coupergateway/features/couper


### PR DESCRIPTION
<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below. For example: "closes #1234" would connect the current pull
request to issue 1234. When we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Description

This PR adds the Couper feature to the public index. This allows users to add the [couper](https://github.com/coupergateway/couper) binary (via gh release) to their stack.

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.