### PR TITLE
feat: added reference to NeoVim from prebuilt binaries feature

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1250,3 +1250,8 @@
   contact: https://github.com/42atomys/devcontainers-features/issues
   repository: https://github.com/42atomys/devcontainers-features
   ociReference: ghcr.io/42atomys/devcontainers-features
+- name: NeoVim (from prebuilt binaries)
+  maintainer: Marcos Bolaños
+  contact: https://github.com/marcosbolanos/devcontainer-features/issues
+  repository: https://github.com/marcosbolanos/devcontainer-features
+  ociReference: ghcr.io/marcosbolanos/devcontainer-features/neovim-prebuilt


### PR DESCRIPTION
## What type of PR is this?

- [ x ] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Added possibility to install NeoVim from prebuilt binaries directly. Currently, available devcontainer NeoVim features are installed either via : 

- apt (2 collections)
- homebrew (1 collection)
- built from source (1 collection)

My implementation offers a clear advantage in that it is extremely lightweight, requires no lengthy installation (just download, unzip, and move a file), offers the latest neovim, and works on almost any linux.



### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.