### PR TITLE
Fix ociReference formatting in collection-index.yml

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1226,7 +1226,7 @@
   maintainer: Azure EdgeActions Developer Experiences Team
   contact: https://github.com/Azure/edgeactions-devcontainers/issues
   repository: https://github.com/Azure/edgeactions-devcontainers
-  ociReference: ghcr.io/Azure/edgeactions-devcontainers/edgeactions
+  ociReference: ghcr.io/Azure/edgeactions-devcontainers
 - name: Git Absorb Feature
   maintainer: baxyz
   contact: https://github.com/baxyz/devcontainer-features/issues


### PR DESCRIPTION

## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

following previous pr: https://github.com/devcontainers/devcontainers.github.io/pull/607

While the collection was showing up in https://containers.dev/collections I don't see the template showing up https://containers.dev/templates

Think this could be because we reference the template itself instead of the collection as the oci reference. PR is to update to point to the collection itself.
