### PR TITLE
feat: add redis_cli, kafka_cli, and neovim binary features

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1257,3 +1257,18 @@
   contact: https://github.com/pairspaces/devcontainers/issues
   repository: https://github.com/pairspaces/devcontainers
   ociReference: ghcr.io/pairspaces/devcontainers/pairspaces
+- name: Neovim (Binary) (neovim)
+  maintainer: caspersg
+  contact: https://github.com/caspersg/devcontainer_features/issues
+  repository: https://github.com/caspersg/devcontainer_features
+  ociReference: http://ghcr.io/caspersg/devcontainer_features/neovim
+- name: Kafka CLI tools (kafka_cli)
+  maintainer: caspersg
+  contact: https://github.com/caspersg/devcontainer_features/issues
+  repository: https://github.com/caspersg/devcontainer_features
+  ociReference: http://ghcr.io/caspersg/devcontainer_features/kafka_cli
+- name: Redis CLI Binary (redis_cli)
+  maintainer: caspersg
+  contact: https://github.com/caspersg/devcontainer_features/issues
+  repository: https://github.com/caspersg/devcontainer_features
+  ociReference: http://ghcr.io/caspersg/devcontainer_features/redis_cli


### PR DESCRIPTION
<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below. For example: "closes #1234" would connect the current pull
request to issue 1234. When we merge the pull request, Github will
automatically close the issue.
-->

- No Related Issue
- No Closes

## Description

This PR adds two three dev-container features to the index:

Redis CLI Binary (redis_cli) - A feature that installs redis-cli from binary
Neovim (Binary) (neovim)- A feature that installs neovim from binary
Kafka CLI tools (kafka_cli) - A feature that installs the kafka CLI tools from binary
All features are available at: https://github.com/caspersg/devcontainer_features

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.