### PR TITLE
Remove https://github.com/favalos/devcontainer-features from list of feature sources

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -383,11 +383,6 @@
   contact: https://github.com/CodeMan99/features/issues
   repository: https://github.com/CodeMan99/features
   ociReference: ghcr.io/codeman99/features
-- name: Features by Favalos
-  maintainer: Fernando Avalos
-  contact: https://github.com/favalos/devcontainer-features/issues
-  repository: https://github.com/favalos/devcontainer-features
-  ociReference: ghcr.io/favalos/devcontainer-features
 - name: Community Templates
   maintainer: devcontainers-community
   contact: https://github.com/orgs/devcontainers-community/discussions


### PR DESCRIPTION

## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

- Related Issue #427

## Description

Removes https://github.com/favalos/devcontainer-features from the list of source repos for devcontainer features because its only feature hasn't been updated in 3 years and https://github.com/devcontainers-extra/features/tree/main/src/temporal-cli provides the same functionality.