### PR TITLE
fix collection-index.yml

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -971,6 +971,7 @@
   maintainer: David Zucker
   contact: https://github.com/davzucky/devcontainers-features-wolfi/issues
   repository: https://github.com/davzucky/devcontainers-features-wolfi
+- name: devcontainer features by ebizbase
   maintainer: eBizBase
   contact: https://github.com/ebizbase/dev-infras/issues
   repository: https://github.com/ebizbase/dev-infras


### PR DESCRIPTION
## Related Issues

- Related Issue #643

## Description

Noticed that the crawler has been failing for the past two days while trying to parse the collection-index.yml
https://github.com/devcontainers/crawler/actions/runs/20774687846/job/59657638950

```
YAMLParseError: Map keys must be unique at line 974, column 3:

  repository: https://github.com/davzucky/devcontainers-features-wolfi
  maintainer: eBizBase
```

Looks like its due to the following PR where a field got removed after an update before merging
https://github.com/devcontainers/devcontainers.github.io/pull/497/changes/c3c31eaf97d54ac34c6ad57a11ac7b04b16cb940

