### PR TITLE
fix: point to collection metadata for amp-devcontainer

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1336,16 +1336,11 @@
   contact: https://github.com/EstebenR/devcontainers/issues
   repository: https://github.com/EstebenR/devcontainers/
   ociReference: ghcr.io/estebenr/devcontainers
-- name: C++ Dev Container Template
+- name: Philips Software Dev Container Templates
   maintainer: Philips Software
   contact: https://github.com/philips-software/amp-devcontainer/issues
   repository: https://github.com/philips-software/amp-devcontainer
-  ociReference: ghcr.io/philips-software/amp-devcontainer/cpp-template
-- name: Rust Dev Container Template
-  maintainer: Philips Software
-  contact: https://github.com/philips-software/amp-devcontainer/issues
-  repository: https://github.com/philips-software/amp-devcontainer
-  ociReference: ghcr.io/philips-software/amp-devcontainer/rust-template
+  ociReference: ghcr.io/philips-software/amp-devcontainer
 - name: Devcontainer Features for Devcontainer Configurations
   maintainer: devcontainer-config
   contact: https://github.com/devcontainer-config/features/issues


### PR DESCRIPTION
<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [ ] Add a new dev container collection
- [x] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

The previous addition to the collection incorrectly pointed to the individual templates, not to the collection metadata. This PR corrects that issue.