### PR TITLE
Add dev container collection focused on multi-repo and rapid renv library setup

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1396,3 +1396,7 @@
   contact: https://github.com/LDlornd/uv-dev-container/issues
   repository: https://github.com/LDlornd/uv-dev-container
   ociReference: ghcr.io/LDlornd/uv-dev-container/lornd-uv
+- name: Dev Container Features for Data Analyses by Miguel Rodo
+  maintiner: MiguelRodo
+  contact: https://github.com/MiguelRodo/DevContainerFeatures/issues
+  ociReference: ghcr.io/MiguelRodo/DevContainerFeatures

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1397,6 +1397,6 @@
   repository: https://github.com/LDlornd/uv-dev-container
   ociReference: ghcr.io/LDlornd/uv-dev-container/lornd-uv
 - name: Dev Container Features for Data Analyses by Miguel Rodo
-  maintainer: MiguelRodo
+  maintainer: Miguel Rodo
   contact: https://github.com/MiguelRodo/DevContainerFeatures/issues
   ociReference: ghcr.io/MiguelRodo/DevContainerFeatures

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1399,4 +1399,5 @@
 - name: Data Project Features by Miguel Rodo
   maintainer: Miguel Rodo
   contact: https://github.com/MiguelRodo/DevContainerFeatures/issues
+  repository: https://github.com/MiguelRodo/DevContainerFeatures
   ociReference: ghcr.io/miguelrodo/devcontainerfeatures

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1396,7 +1396,7 @@
   contact: https://github.com/LDlornd/uv-dev-container/issues
   repository: https://github.com/LDlornd/uv-dev-container
   ociReference: ghcr.io/LDlornd/uv-dev-container/lornd-uv
-- name: Dev Container Features for Data Analyses by Miguel Rodo
+- name: Data Project Features by Miguel Rodo
   maintainer: Miguel Rodo
   contact: https://github.com/MiguelRodo/DevContainerFeatures/issues
-  ociReference: ghcr.io/MiguelRodo/DevContainerFeatures
+  ociReference: ghcr.io/miguelrodo/devcontainerfeatures

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1397,6 +1397,6 @@
   repository: https://github.com/LDlornd/uv-dev-container
   ociReference: ghcr.io/LDlornd/uv-dev-container/lornd-uv
 - name: Dev Container Features for Data Analyses by Miguel Rodo
-  maintiner: MiguelRodo
+  maintainer: MiguelRodo
   contact: https://github.com/MiguelRodo/DevContainerFeatures/issues
   ociReference: ghcr.io/MiguelRodo/DevContainerFeatures


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

None.

## Description

I have several devcontainer features that I frequently use, available at https://github.com/MiguelRodo/DevContainerFeatures. The two main ones included in this collection are:

- `repos` — Installs a utility to easily clone and set up multiple Git repositories from a single, simple `repos.list` file.
- `renv-cache` — builds and installs R packages from `renv.lock` during container build into a global `renv` cache that persists past the container build and is automatically available to R analyses. This improves container start time and ensures package state is more easily restored in the future.

I am not aware of an alternative to the `repos` feature. The `renv-cache` feature is quite distinct from the `rocker` `renv-cache` feature, which does not install packages into a cache during container build time.

It also has three other, more minor features:

- `apptainer` — Installs Apptainer.  
- `mermaid` — Installs the Mermaid CLI.  
- `fit-sne` — Installs FIt-SNE, an efficient implementation of t-SNE.

I highly doubt an equivalent to fit-sne is available, and I could not see anything that obviously set up mermaid or apptainer. 

### Collection checklist

- [x] Collection name: Data Project Features by Miguel Rodo
- [x] Maintainer name: Miguel Rodo
- [x] Maintainer contact link: https://github.com/MiguelRodo/DevContainerFeatures/issues
- [x] Repository URL: https://github.com/MiguelRodo/DevContainerFeatures
- [x] OCI Reference(s): ghcr.io/miguelrodo/devcontainerfeatures
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.