### PR TITLE
Add alan-chen-dongsheng/devcontainer-templates to collection index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1396,3 +1396,8 @@
   contact: https://github.com/LDlornd/uv-dev-container/issues
   repository: https://github.com/LDlornd/uv-dev-container
   ociReference: ghcr.io/LDlornd/uv-dev-container/lornd-uv
+- name: Dev Container Features by AlanChen
+  maintainer: alan-chen-dongsheng
+  contact: https://github.com/alan-chen-dongsheng/devcontainer-templates/issues
+  repository: https://github.com/alan-chen-dongsheng/devcontainer-templates
+  ociReference: ghcr.io/alan-chen-dongsheng/devcontainer-templates


### PR DESCRIPTION
  What type of PR is this?

   - [X]  Add a new dev container collection

  Related Issues

  N/A

  Description

  Add alan-chen-dongsheng/devcontainer-templates to the collection index.

  This collection provides a comprehensive AI Compiler Environment dev container template (ai_compiler_env) featuring LLVM/Clang full toolchain, ccache, zsh + oh-my-zsh, Python (uv), Node.js, Rust, and full LSP
  configuration for C++/Python/TypeScript/JavaScript.

  Collection checklist

   - [X]  Collection name: Dev Container Features by AlanChen
   - [X]  Maintainer name: alan-chen-dongsheng
   - [X]  Maintainer contact link: https://github.com/alan-chen-dongsheng/devcontainer-templates/issues
   - [X]  Repository URL: https://github.com/alan-chen-dongsheng/devcontainer-templates
   - [X]  OCI Reference: ghcr.io/alan-chen-dongsheng/devcontainer-templates
   - [X]  I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.