### PR TITLE
Add Doppler tools to collections index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1391,6 +1391,11 @@
   contact: https://github.com/ttyrho/devcontainer-features/issues
   repository: https://github.com/ttyrho/devcontainer-features
   ociReference: ghcr.io/ttyrho/devcontainer-features
+- name: Doppler Features
+  maintainer: Doppler Team
+  contact: https://github.com/DopplerHQ/devcontainer-features/issues
+  repository: https://github.com/DopplerHQ/devcontainer-features
+  ociReference: ghcr.io/dopplerhq/devcontainer-features
 - name: lornd-uv
   maintainer: lornd
   contact: https://github.com/LDlornd/uv-dev-container/issues


### PR DESCRIPTION
<!--
     📖 Before submitting a Pull Request, please ensure you've read the Contributing Guide: https://containers.dev/implementors/contributing/
-->

## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below. For example: "closes #1234" would connect the current pull
request to issue 1234. When we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Description

This collection currently just includes a feature which installs the [Doppler CLI](https://github.com/DopplerHQ/cli).

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference (must be the collection root, e.g. `ghcr.io/<owner>/<repo>` — one entry per repository, not one per Feature; do not include `http://` or `https://`)
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.