### PR TITLE
Added `trunk-devcontainer-feature`

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1476,3 +1476,8 @@
   contact: https://github.com/nkdui/devcontainer-features/issues
   repository: https://github.com/nkdui/devcontainer-features
   ociReference: ghcr.io/nkdui/devcontainer-features
+- name: trunk-rs devcontainer feature
+  maintainer: Mark Hornsby (mrhornsby)
+  contact: https://github.com/mrhornsby/trunk-devcontainer-feature/issues
+  repository: https://github.com/mrhornsby/trunk-devcontainer-feature
+  ociReference: ghcr.io/mrhornsby/trunk-devcontainer-feature/trunk

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1477,7 +1477,7 @@
   repository: https://github.com/nkdui/devcontainer-features
   ociReference: ghcr.io/nkdui/devcontainer-features
 - name: trunk-rs devcontainer feature
-  maintainer: Mark Hornsby (mrhornsby)
+  maintainer: mrhornsby
   contact: https://github.com/mrhornsby/trunk-devcontainer-feature/issues
   repository: https://github.com/mrhornsby/trunk-devcontainer-feature
-  ociReference: ghcr.io/mrhornsby/trunk-devcontainer-feature/trunk
+  ociReference: ghcr.io/mrhornsby/trunk-devcontainer-feature


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

n/a

## Description

This PR adds a new feature supporting the [trunk-rs](https://github.com/trunk-rs/trunk) rust project (distinct from the existing [trunk-io](https://trunk.io) feature listed in the index).

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference (must be the collection root, e.g. `ghcr.io/<owner>/<repo>` — one entry per repository, not one per Feature; do not include `http://` or `https://`)
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.