### PR TITLE
Add Magento Open Source Dev Container Templates collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1476,3 +1476,8 @@
   contact: https://github.com/nkdui/devcontainer-features/issues
   repository: https://github.com/nkdui/devcontainer-features
   ociReference: ghcr.io/nkdui/devcontainer-features
+- name: Magento Open Source Dev Container Templates
+  maintainer: Doug Hatcher
+  contact: https://github.com/doughatcher/devcontainer-templates/issues
+  repository: https://github.com/doughatcher/devcontainer-templates
+  ociReference: ghcr.io/doughatcher/devcontainer-templates


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Description

Adds a new collection: **Magento Open Source Dev Container Templates** at https://github.com/doughatcher/devcontainer-templates.

The collection currently ships one template, `magento`, which provides a complete Magento 2 (Open Source / Community Edition) development environment with PHP-FPM, MariaDB, Redis, RabbitMQ, OpenSearch, MailHog, and an optional Nginx sidecar. The template's `postCreateCommand` auto-runs `composer install` and `bin/magento setup:install`, so devs land in a working Magento store on first start. It supports both local Docker and GitHub Codespaces, with bundled Playwright e2e tests for checkout and admin login flows.

## History

This is a re-submission of #500, which I opened in December 2024 and closed shortly after with the comment _"I have been asked to donate this work to my organization and release it in their namespace."_ The corporate fork has since been archived; the OSS variant is now back under my personal `doughatcher` namespace as a community-maintained collection. The corporate-internal variant kept the work-specific extensions (Adobe IMS, Adobe I/O CLI, Magento Cloud CLI, Zscaler cert handling) and is no longer publicly active.

### Collection checklist

- [x] Collection name: Magento Open Source Dev Container Templates
- [x] Maintainer name: Doug Hatcher
- [x] Maintainer contact link: https://github.com/doughatcher/devcontainer-templates/issues
- [x] Repository URL: https://github.com/doughatcher/devcontainer-templates
- [x] OCI Reference: ghcr.io/doughatcher/devcontainer-templates
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.