### PR TITLE
Add collection ghcr.io/aqua/devcontainer-antigravity-cli

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1503,5 +1503,6 @@
   ociReference: ghcr.io/nkaaf/devcontainer-features
 - name: Antigravity CLI feature by aqua
   maintainer: aqua
-  contact: https://github.com/aqua/devcontainer-antigravity-cli
+  contact: https://github.com/aqua/devcontainer-antigravity-cli/issues
+  repository: https://github.com/aqua/devcontainer-antigravity-cli
   ociReference: ghcr.io/aqua/devcontainer-antigravity-cli

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1501,3 +1501,7 @@
   contact: https://github.com/nkaaf/devcontainer-features/issues
   repository: https://github.com/nkaaf/devcontainer-features
   ociReference: ghcr.io/nkaaf/devcontainer-features
+- name: Antigravity CLI feature by aqua
+  maintainer: aqua
+  contact: https://github.com/aqua/devcontainer-antigravity-cli
+  ociReference: ghcr.io/aqua/devcontainer-antigravity-cli


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

- Related Issue # (none)
- Closes # (none)

## Description

Adds a single-feature collection ghcr.io/aqua/devcontainer-antigravity-cli, to install Google's Antigravity CLI.  Google has announced the deprecation of gemini-cli which antigravity-cli replaces, and currently there's no feature for it.

### Collection checklist
_If your PR contributes a new collection, please utilize this checklist:_
- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference (must be the collection root, e.g. `ghcr.io/<owner>/<repo>` — one entry per repository, not one per Feature; do not include `http://` or `https://`)
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.