### PR TITLE
feat: add Dev Container Extras by XavierBeheydt collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1501,3 +1501,8 @@
   contact: https://github.com/nkaaf/devcontainer-features/issues
   repository: https://github.com/nkaaf/devcontainer-features
   ociReference: ghcr.io/nkaaf/devcontainer-features
+- name: Dev Container Extras
+  maintainer: XavierBeheydt
+  contact: https://github.com/XavierBeheydt/devcontainer-extras/issues
+  repository: https://github.com/XavierBeheydt/devcontainer-extras
+  ociReference: ghcr.io/xavierbeheydt/devcontainer-extras

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1501,7 +1501,7 @@
   contact: https://github.com/nkaaf/devcontainer-features/issues
   repository: https://github.com/nkaaf/devcontainer-features
   ociReference: ghcr.io/nkaaf/devcontainer-features
-- name: Dev Container Extras
+- name: Dev Container Extras by XavierBeheydt
   maintainer: XavierBeheydt
   contact: https://github.com/XavierBeheydt/devcontainer-extras/issues
   repository: https://github.com/XavierBeheydt/devcontainer-extras


### PR DESCRIPTION
## Add Dev Container Extras by XavierBeheydt to the collection index

Adds the [Dev Container Extras by XavierBeheydt](https://github.com/XavierBeheydt/devcontainer-extras) feature collection — a personal collection of dev container extras maintained by Xavier Beheydt.

### Features included

- **lazyvim** — Installs the [LazyVim](https://www.lazyvim.org/) starter configuration as the default Neovim config. Skipped if `~/.config/nvim` already exists.

### OCI Reference

`ghcr.io/xavierbeheydt/devcontainer-extras`