### PR TITLE
Add Ansible DevTools with Claude Code templates collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1551,3 +1551,8 @@
   contact: https://github.com/dnegstad/devcontainer-dev-certs/issues
   repository: https://github.com/dnegstad/devcontainer-dev-certs
   ociReference: ghcr.io/dnegstad/devcontainer-dev-certs
+- name: Ansible DevTools with Claude Code
+  maintainer: leogallego
+  contact: https://github.com/leogallego/ansible-claude-code-devcontainer/issues
+  repository: https://github.com/leogallego/ansible-claude-code-devcontainer
+  ociReference: ghcr.io/leogallego/ansible-claude-code-devcontainer


### PR DESCRIPTION
Adds the [Ansible DevTools with Claude Code](https://github.com/leogallego/ansible-claude-code-devcontainer) templates collection to the community index.

**Templates included:**
- `claude-code-ansible` — Ansible development environment (Fedora) with Claude Code CLI, ansible-lint, molecule, and a Tinyproxy + nftables network sandbox
- `claude-code` — General-purpose Node.js environment with Claude Code CLI and proxy sandbox

**OCI reference:** `ghcr.io/leogallego/ansible-claude-code-devcontainer`

Both packages are public and downloadable without authentication.