### PR TITLE
Add Matilda Code Features to collection index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1570,4 +1570,4 @@
   maintainer: Maincode
   contact: https://github.com/MaincodeHQ/devcontainer-features/issues
   repository: https://github.com/MaincodeHQ/devcontainer-features
-  ociReference: ghcr.io/maincodehq/devcontainer-features
+  ociReference: ghcr.io/maincodehq/devcontainer-features/matilda-code

--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1566,3 +1566,8 @@
   contact: https://github.com/bare-devcontainer/templates/issues
   repository: https://github.com/bare-devcontainer/templates
   ociReference: ghcr.io/bare-devcontainer/templates
+- name: Matilda Code Features
+  maintainer: Maincode
+  contact: https://github.com/MaincodeHQ/devcontainer-features/issues
+  repository: https://github.com/MaincodeHQ/devcontainer-features
+  ociReference: ghcr.io/maincodehq/devcontainer-features


### PR DESCRIPTION
## Summary

Adds the **Maincode** dev container Feature collection to the public collection index so it is discoverable in VS Code Dev Containers, GitHub Codespaces, and on https://containers.dev/features.

- **Collection name:** Matilda Code Features
- **Maintainer:** Maincode
- **Repository:** https://github.com/MaincodeHQ/devcontainer-features
- **OCI reference:** `ghcr.io/maincodehq/devcontainer-features/matilda-code`

## What the collection provides

The collection currently publishes the [`matilda-code`](https://github.com/MaincodeHQ/devcontainer-features/tree/main/src/matilda-code) Feature, which installs the Matilda Code CLI (`@maincode-ai/matilda-code`) — Maincode's terminal-based AI coding agent. It provisions Node.js >= 22 automatically when the base image does not provide it, then installs the CLI globally.

The Feature is already published to GHCR under the `ociReference` above (tags `1`, `1.0`, `1.0.0`, `latest`), and the source repository is public.

## Checklist

- [x] Entry follows the existing `name` / `maintainer` / `contact` / `repository` / `ociReference` schema used by all other entries.
- [x] Referenced OCI artifact is publicly readable at `ghcr.io/maincodehq/devcontainer-features/matilda-code`.
- [x] Referenced source repository is public.
