### PR TITLE
Add ITplusX Dev Container Features collection to the index

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1566,3 +1566,8 @@
   contact: https://github.com/bare-devcontainer/templates/issues
   repository: https://github.com/bare-devcontainer/templates
   ociReference: ghcr.io/bare-devcontainer/templates
+- name: ITplusX Dev Container Features
+  maintainer: ITplusX
+  contact: https://github.com/itplusx/devcontainer-features/issues
+  repository: https://github.com/itplusx/devcontainer-features
+  ociReference: ghcr.io/itplusx/devcontainer-features


### PR DESCRIPTION
Adds the `ghcr.io/itplusx/devcontainer-features` collection to the community index.

- Repository: https://github.com/itplusx/devcontainer-features
- Published and public on GHCR
- Contains one feature: `shared-pnpm-store` — mounts a shared Docker volume as the pnpm store directory via `containerEnv`, so packages are downloaded once and reused across devcontainers.