### PR TITLE
Add LiquiLens Evidence Carrier Feature collection

### DIFF
--- a/_data/collection-index.yml
+++ b/_data/collection-index.yml
@@ -1591,3 +1591,8 @@
   contact: https://github.com/mkvlrn/mise-devcontainers/issues
   repository: https://github.com/mkvlrn/mise-devcontainers
   ociReference: ghcr.io/mkvlrn/mise-devcontainers
+- name: LiquiLens Evidence Carrier Features
+  maintainer: beepboop2025
+  contact: https://github.com/beepboop2025/liquilens-devcontainer-features/issues
+  repository: https://github.com/beepboop2025/liquilens-devcontainer-features
+  ociReference: ghcr.io/beepboop2025/liquilens-devcontainer-features


### PR DESCRIPTION
## What type of PR is this?

- [x] Add a new dev container collection
- [ ] Update to an existing dev container collection
- [ ] Documentation/spec update
- [ ] Other containers.dev site update (UX, layout, etc)

## Related Issues

None.

## Description

Adds the public LiquiLens Evidence Carrier Feature collection for an offline, read-only evidence-verification CLI and MCP stdio server. This submission is under external review and the collection is not represented as listed until this PR is merged.

The collection root resolves anonymously as `ghcr.io/beepboop2025/liquilens-devcontainer-features@sha256:54882f74db5b1a81d1ca68b7bc773a63ddf6e2667e479ab61a79b334243e6a5b`. Feature `liquilens-evidence:1.0.0` resolves as `sha256:79ac17d7c3f91dc9360c6aa63cb9e4fa0081d5c81e1a1492b2198a8280f5b22d`. Hosted anonymous consumer evidence: https://github.com/beepboop2025/liquilens-devcontainer-features/actions/runs/32737162315

### Collection checklist

- [x] Collection name
- [x] Maintainer name
- [x] Maintainer contact link (i.e. link to a GitHub repo, email)
- [x] Repository URL
- [x] OCI Reference (collection root, one entry per repository)
- [x] I acknowledge that this collection provides new functionality, distinct from the existing collections part of this index.

This is an independent community Feature and does not claim endorsement by Microsoft, GitHub, Visual Studio Code, Codespaces, or Dev Containers.